### PR TITLE
nix: init package, modules, tests

### DIFF
--- a/.github/workflows/nix-pr-check.yml
+++ b/.github/workflows/nix-pr-check.yml
@@ -1,0 +1,37 @@
+name: Nix flake and NixOS tests
+
+on:
+  pull_request:
+    branches: [master, main]
+    paths:
+      - "flake.*"
+      - "distro/nix/**"
+jobs:
+  check-flake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          enable_kvm: true
+          extra_nix_config: |
+            system-features = nixos-test benchmark big-parallel kvm
+
+      - name: Check the flake
+        run: nix flake check -L
+
+      - name: Run NixOS module test
+        run: nix build .#nixosTests.x86_64-linux.nixos-module -L
+
+      - name: Run NixOS service start test
+        run: nix build .#nixosTests.x86_64-linux.nixos-service-start-module -L
+
+      - name: Run home-manager module test
+        run: nix build .#nixosTests.x86_64-linux.home-manager-module -L

--- a/.github/workflows/update-vendor-hash.yml
+++ b/.github/workflows/update-vendor-hash.yml
@@ -1,0 +1,69 @@
+# SOURCE: https://github.com/AvengeMedia/DankMaterialShell/blob/ddf943846fb437cb255d6de66e6acfe3a07dad2f/.github/workflows/update-vendor-hash.yml
+
+name: Update Vendor Hash
+
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "core/go.mod"
+      - "core/go.sum"
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  update-vendor-hash:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Update vendorHash in flake.nix
+        run: |
+          set -euo pipefail
+          echo "Attempting nix build to get new vendorHash..."
+          if output=$(nix build .#dcal 2>&1); then
+            echo "Build succeeded, no hash update needed"
+            exit 0
+          fi
+          new_hash=$(echo "$output" | grep -oP "got:\s+\K\S+" | head -n1 || true)
+          [ -n "$new_hash" ] || { echo "Could not extract new vendorHash"; echo "$output"; exit 1; }
+          current_hash=$(grep -oP 'vendorHash = "\K[^"]+' flake.nix)
+          [ "$current_hash" = "$new_hash" ] && { echo "vendorHash already up to date"; exit 0; }
+          sed -i "s|vendorHash = \"$current_hash\"|vendorHash = \"$new_hash\"|" flake.nix
+          echo "Verifying build with new vendorHash..."
+          nix build .#dcal
+          echo "vendorHash updated successfully!"
+
+      - name: Commit and push vendorHash update
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet flake.nix; then
+            git config user.name "dms-ci[bot]"
+            git config user.email "dms-ci[bot]@users.noreply.github.com"
+            git add flake.nix
+            git commit -m "nix: update vendorHash for go.mod changes" || exit 0
+            git pull --rebase origin ${{ github.ref_name }}
+            git push https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git HEAD:${{ github.ref_name }}
+          else
+            echo "No changes to flake.nix"
+          fi

--- a/distro/nix/home.nix
+++ b/distro/nix/home.nix
@@ -1,0 +1,57 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}@args:
+let
+  cfg = config.programs.dank-calendar;
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  imports = [ (import ./options.nix args) ];
+
+  options.programs.dank-calendar.settings = lib.mkOption {
+    type = jsonFormat.type;
+    default = { };
+    description = "Dank Calendar UI settings written to ~/.config/dankcal/ui-settings.json.";
+    example = lib.literalExpression ''
+      {
+        remindersEnabled = true;
+        use24HourClock = true;
+        defaultReminderMinutes = 10;
+        snoozeMinutes = 5;
+      }
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.dank-calendar.systemd.target = lib.mkDefault config.wayland.systemd.target;
+
+    home.packages = [
+      cfg.package
+      cfg.quickshell.package
+    ];
+
+    systemd.user.services.dcal = lib.mkIf cfg.systemd.enable {
+      Unit = {
+        Description = "DankCalendar";
+        PartOf = [ cfg.systemd.target ];
+        After = [ cfg.systemd.target ];
+      };
+
+      Service = {
+        ExecStart = lib.getExe cfg.package + " run --session --hidden";
+        Restart = "on-failure";
+        RestartSec = "2";
+        Slice = "app.slice";
+      };
+
+      Install.WantedBy = [ cfg.systemd.target ];
+    };
+
+    xdg.configFile."dankcal/ui-settings.json" = lib.mkIf (cfg.settings != { }) {
+      source = jsonFormat.generate "ui-settings.json" cfg.settings;
+    };
+  };
+}

--- a/distro/nix/nixos.nix
+++ b/distro/nix/nixos.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}@args:
+let
+  cfg = config.programs.dank-calendar;
+in
+{
+  imports = [ (import ./options.nix args) ];
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+      cfg.quickshell.package
+    ];
+
+    systemd.packages = lib.mkIf cfg.systemd.enable [ cfg.package ];
+
+    systemd.user.services.dcal = lib.mkIf cfg.systemd.enable {
+      wantedBy = [ cfg.systemd.target ];
+      restartIfChanged = cfg.systemd.restartIfChanged;
+      path = [ cfg.quickshell.package ];
+    };
+  };
+}

--- a/distro/nix/options.nix
+++ b/distro/nix/options.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  dcalPkgs,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) types;
+in
+{
+  options.programs.dank-calendar = {
+    enable = lib.mkEnableOption "DankCalendar";
+
+    package = lib.mkPackageOption dcalPkgs "dankcalendar" {
+      extraDescription = "The DankCalendar package to use (defaults to be built from source)";
+    };
+
+    quickshell = {
+      package = lib.mkPackageOption pkgs "quickshell" {
+        extraDescription = "The Quickshell package used to launch the calendar UI";
+      };
+    };
+
+    systemd = {
+      enable = lib.mkEnableOption "DankCalendar systemd startup";
+
+      target = lib.mkOption {
+        type = types.str;
+        default = "graphical-session.target";
+        description = "Systemd target that will automatically start dcal.";
+      };
+
+      restartIfChanged = lib.mkOption {
+        type = types.bool;
+        default = true;
+        description = "Auto-restart dcal.service when dank-calendar changes";
+      };
+    };
+  };
+}

--- a/distro/nix/tests/default.nix
+++ b/distro/nix/tests/default.nix
@@ -1,0 +1,21 @@
+{
+  self,
+  pkgs,
+  ...
+}:
+rec {
+  all = pkgs.symlinkJoin {
+    name = "dankcalendar-nixos-tests";
+    paths = [
+      nixos-module
+      nixos-service-start-module
+      home-manager-module
+    ];
+  };
+
+  nixos-module = import ./nixos-module.nix { inherit self pkgs; };
+
+  nixos-service-start-module = import ./nixos-service-start-module.nix { inherit self pkgs; };
+
+  home-manager-module = import ./home-manager-module.nix { inherit self pkgs; };
+}

--- a/distro/nix/tests/home-manager-module.nix
+++ b/distro/nix/tests/home-manager-module.nix
@@ -1,0 +1,74 @@
+{
+  self,
+  pkgs,
+  ...
+}:
+let
+  homeManagerNixosModule =
+    (fetchTarball {
+      url = "https://github.com/nix-community/home-manager/archive/c03e4752899e55705dfa63979abd885c582a5c48.tar.gz";
+      sha256 = "0c3jm12hgqns8wlgid5pfyg5qn39lsf7adv6wv5swjh54mhi3qj0";
+    })
+    + "/nixos";
+in
+pkgs.testers.runNixOSTest {
+  name = "dankcalendar-home-manager-module";
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ homeManagerNixosModule ];
+
+      users.users.danklinux = {
+        isNormalUser = true;
+        createHome = true;
+        home = "/home/danklinux";
+        extraGroups = [ "wheel" ];
+      };
+
+      home-manager.useGlobalPkgs = true;
+      home-manager.useUserPackages = true;
+
+      home-manager.users.danklinux =
+        { pkgs, ... }:
+        {
+          imports = [ self.homeModules.dank-calendar ];
+
+          home.username = "danklinux";
+          home.homeDirectory = "/home/danklinux";
+          home.stateVersion = "25.11";
+
+          programs.dank-calendar = {
+            enable = true;
+            systemd = {
+              enable = true;
+              target = "default.target";
+            };
+
+            settings = {
+              remindersEnabled = false;
+              use24HourClock = false;
+              defaultReminderMinutes = 15;
+            };
+          };
+        };
+
+      system.stateVersion = "25.11";
+    };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("su -- danklinux -c 'command -v dcal'")
+    machine.succeed("su -- danklinux -c 'test -f ~/.config/systemd/user/dcal.service'")
+    machine.succeed("su -- danklinux -c 'test -L ~/.config/systemd/user/default.target.wants/dcal.service'")
+
+    machine.succeed("su -- danklinux -c 'test -f ~/.config/dankcal/ui-settings.json'")
+    settings = json.loads(machine.succeed("su -- danklinux -c 'cat ~/.config/dankcal/ui-settings.json'"))
+    t.assertFalse(settings["remindersEnabled"])
+    t.assertFalse(settings["use24HourClock"])
+    t.assertEqual(settings["defaultReminderMinutes"], 15)
+  '';
+}

--- a/distro/nix/tests/nixos-module.nix
+++ b/distro/nix/tests/nixos-module.nix
@@ -1,0 +1,35 @@
+{
+  self,
+  pkgs,
+  ...
+}:
+pkgs.testers.runNixOSTest {
+  name = "dankcalendar-nixos-module";
+
+  nodes.machine = {
+    imports = [
+      self.nixosModules.dank-calendar
+    ];
+
+    users.users.danklinux = {
+      isNormalUser = true;
+      extraGroups = [ "wheel" ];
+    };
+
+    programs.dank-calendar = {
+      enable = true;
+      systemd.enable = true;
+    };
+
+    system.stateVersion = "25.11";
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("command -v dcal")
+    machine.succeed("command -v qs")
+    machine.succeed("su -- danklinux -c 'dcal --help >/dev/null'")
+    machine.succeed("test -f /run/current-system/sw/share/systemd/user/dcal.service")
+  '';
+}

--- a/distro/nix/tests/nixos-service-start-module.nix
+++ b/distro/nix/tests/nixos-service-start-module.nix
@@ -1,0 +1,38 @@
+{
+  self,
+  pkgs,
+  ...
+}:
+pkgs.testers.runNixOSTest {
+  name = "dankcalendar-nixos-service-start-module";
+
+  nodes.machine = {
+    imports = [
+      self.nixosModules.dank-calendar
+    ];
+
+    users.users.danklinux = {
+      isNormalUser = true;
+      extraGroups = [ "wheel" ];
+    };
+
+    programs.dank-calendar = {
+      enable = true;
+      systemd = {
+        enable = true;
+        target = "default.target";
+      };
+    };
+
+    system.stateVersion = "25.11";
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    unit = "/run/current-system/sw/share/systemd/user/dcal.service"
+    machine.succeed(f"test -f {unit}")
+    machine.succeed(f"grep -q 'run --session --hidden' {unit}")
+    machine.succeed("test -e /etc/systemd/user/default.target.wants/dcal.service")
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
               "-s"
               "-w"
               "-X main.Version=${version}"
-              "-X main.Commit=${self.rev or "dirty"}"
+              "-X main.Commit=${self.shortRev or self.dirtyShortRev or "dirty"}"
             ];
 
             nativeBuildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,164 @@
+{
+  description = "DankCalendar";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      goModVersion =
+        let
+          content = builtins.readFile ./core/go.mod;
+          lines = builtins.filter builtins.isString (builtins.split "\n" content);
+          goLines = builtins.filter (l: builtins.match "go [0-9]+\\..*" l != null) lines;
+          matched =
+            if goLines != [ ] then builtins.match "go ([0-9]+)\\.([0-9]+).*" (builtins.head goLines) else null;
+        in
+        if matched != null then
+          {
+            major = builtins.elemAt matched 0;
+            minor = builtins.elemAt matched 1;
+          }
+        else
+          {
+            major = "1";
+            minor = "25";
+          };
+      goForPkgs = pkgs: pkgs.${"go_${goModVersion.major}_${goModVersion.minor}"};
+
+      forEachSystem =
+        fn:
+        nixpkgs.lib.genAttrs [ "aarch64-linux" "x86_64-linux" ] (
+          system: fn system nixpkgs.legacyPackages.${system}
+        );
+
+      mkModuleWithDcalPkgs =
+        modulePath:
+        args@{ pkgs, ... }:
+        {
+          imports = [
+            (import modulePath (args // { dcalPkgs = buildDcalPkgs pkgs; }))
+          ];
+        };
+
+      mkDcal =
+        pkgs:
+        (
+          let
+            version = "0.1.0";
+          in
+          (pkgs.buildGoModule.override { go = goForPkgs pkgs; }) {
+            inherit version;
+            pname = "dankcalendar";
+            src = ./core;
+            vendorHash = "sha256-RBqKsr+bAvPqLaLw+4nJQ8j1r5j9hwgK0qFMmvTKuzc=";
+
+            subPackages = [ "cmd/dcal" ];
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.Version=${version}"
+              "-X main.Commit=${self.rev or "dirty"}"
+            ];
+
+            nativeBuildInputs = with pkgs; [
+              installShellFiles
+              makeWrapper
+            ];
+
+            postInstall = ''
+              mkdir -p $out/share/quickshell/dankcalendar
+              cp -r ${./quickshell}/. $out/share/quickshell/dankcalendar/
+
+              install -Dm644 ${./assets/com.danklinux.dankcalendar.desktop} \
+                $out/share/applications/com.danklinux.dankcalendar.desktop
+              install -Dm644 ${./quickshell/assets/dankcalendar.svg} \
+                $out/share/icons/hicolor/scalable/apps/dankcalendar.svg
+
+              install -Dm644 ${./assets/systemd/dcal.service} \
+                $out/lib/systemd/user/dcal.service
+              substituteInPlace $out/lib/systemd/user/dcal.service \
+                --replace-fail /usr/bin/dcal $out/bin/dcal
+
+              wrapProgram $out/bin/dcal \
+                --add-flags "-c $out/share/quickshell/dankcalendar"
+
+              installShellCompletion --cmd dcal \
+                --bash <($out/bin/dcal completion bash) \
+                --fish <($out/bin/dcal completion fish) \
+                --zsh <($out/bin/dcal completion zsh)
+            '';
+
+            meta = {
+              description = "Local, Google, Microsoft, and CalDAV calendars for the dank desktop";
+              homepage = "https://github.com/AvengeMedia/dankcalendar";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "dcal";
+              platforms = pkgs.lib.platforms.linux;
+            };
+          }
+        );
+
+      buildDcalPkgs = pkgs: {
+        dankcalendar = mkDcal pkgs;
+      };
+    in
+    {
+      packages = forEachSystem (
+        system: pkgs: {
+          dankcalendar = mkDcal pkgs;
+          default = self.packages.${system}.dankcalendar;
+        }
+      );
+
+      lib = { inherit mkDcal buildDcalPkgs; };
+
+      homeModules.dank-calendar = mkModuleWithDcalPkgs ./distro/nix/home.nix;
+
+      homeModules.default = self.homeModules.dank-calendar;
+
+      nixosModules.dank-calendar = mkModuleWithDcalPkgs ./distro/nix/nixos.nix;
+
+      nixosModules.default = self.nixosModules.dank-calendar;
+
+      devShells = forEachSystem (
+        system: pkgs: {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              (goForPkgs pkgs)
+              go-mockery_2
+              gopls
+              delve
+              go-tools
+              gnumake
+
+              quickshell
+
+              prek
+              uv
+              python3
+
+              nixd
+              nil
+            ];
+
+            shellHook = ''
+              touch quickshell/.qmlls.ini 2>/dev/null
+              if [ ! -f .git/hooks/pre-commit ]; then prek install; fi
+            '';
+          };
+        }
+      );
+
+      nixosTests = nixpkgs.lib.genAttrs [ "aarch64-linux" "x86_64-linux" ] (
+        system:
+        import ./distro/nix/tests {
+          inherit self;
+          pkgs = nixpkgs.legacyPackages.${system};
+        }
+      );
+    };
+}


### PR DESCRIPTION
Inits a Nix flake, heavily based on the one from upstream due to architectural similarities. The flake includes basic NixOS/home-manager modules and a package, besides tests.

I haven't particularly tested the home-manager module due to not having it installed in my system, but at least the vm tests worked.

Important things to note:
- Currently, the version is hardcoded at the flake as `0.1.0` (in DankMaterialShell, we have the quickshell/VERSION file for that);
- The vendor hash action, scraped from the DankMaterialShell repo, needs the secrets in order to work.