### PR TITLE
flake: updating vendorHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
             inherit version;
             pname = "dankcalendar";
             src = ./core;
-            vendorHash = "sha256-a9H88PwvuCRaTVV8FIg5SGK2nehg5MN/fJ92Wi+RAIU=";
+            vendorHash = "sha256-Oz7tLJ/4zQ+fcg+MM1cqzElynXOYcK3Eu7gzhXDF734=";
 
             subPackages = [ "cmd/dcal" ];
 


### PR DESCRIPTION
Prior vendorHash was breaking nix builds due to updated `go.mod` and `go.sum`. 

<img width="1711" height="228" alt="image" src="https://github.com/user-attachments/assets/ea91a850-e773-4faa-9eec-f3da28b6674a" />
