### PR TITLE
sync: refresh meeting URLs for existing Google accounts

### DIFF
--- a/core/ent/migrate/migrations/20260630202500_resync_meeting_urls.sql
+++ b/core/ent/migrate/migrations/20260630202500_resync_meeting_urls.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Meeting URLs are derived from provider data during sync. Existing cursors
+-- prevent events stored before the meeting_url field was added from being
+-- fetched again, so invalidate them once to rebuild that field.
+UPDATE `calendars` SET `sync_token` = NULL WHERE `sync_token` IS NOT NULL;
+
+-- +goose Down
+-- Sync cursors are remote, ephemeral state and cannot be reconstructed.
+SELECT 1;

--- a/core/ent/migrate/migrations/atlas.sum
+++ b/core/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:RWlZ7ZxaeW0NG+AWFSrsbgAdL9J/A4hJX764Y+1zRc4=
+h1:d1ZOvxj2qUu3YQyyMObuQ2PY3t3PC/rK35I1qooWkvM=
 20260615203534_initial.sql h1:qvyo54Em5G9SLnLp5eAXjsH13fAnxWTxNBt2NzVZxOQ=
 20260615203550_add_account_reauth_fields.sql h1:MJEw726QlXfv/LEge0hZc2FIOozrBbWx/5jle5yNBrY=
 20260615213446_add_calendar_reminder_overrides.sql h1:mOwabEvPxoDAF1ry3mvtlEypCYnDBnXBRAybv57KQgQ=
@@ -7,3 +7,4 @@ h1:RWlZ7ZxaeW0NG+AWFSrsbgAdL9J/A4hJX764Y+1zRc4=
 20260625130333_add_invitation_state.sql h1:hMvgCbc1Cs928F2gBIrCXQ6fDD7YoPVhPyRjs9iOxug=
 20260626184447_add_tasks.sql h1:o0rk+wUjWdDxjSY4VjHAE0i0apspazTaBewzLHNLko4=
 20260629125249_add_account_sync_notice.sql h1:BFnxA+blL01fMdkTFGm/oYumbZUR4VrZQ4zhTxh3cGk=
+20260630202500_resync_meeting_urls.sql h1:MtUJrBBQynd7O52BnpUVuTv9wslFWL3wJ3IZLkCd184=

--- a/core/internal/providers/google/provider.go
+++ b/core/internal/providers/google/provider.go
@@ -73,9 +73,9 @@ func (p *Provider) ListCalendars(ctx context.Context) ([]cal.Calendar, error) {
 		return taskLists, nil
 	case calErr != nil:
 		return nil, fmt.Errorf("list google calendars: %w", classifyAuthErr(calErr))
-	case taskErr != nil && isServiceDisabled(taskErr):
+	case taskErr != nil && isOptionalServiceUnavailable(taskErr):
 		p.notices = append(p.notices, cal.NoticeTasksUnavailable)
-		log.Warnf("account %s: Google Tasks API disabled, syncing calendars only: %v", p.account.ID, taskErr)
+		log.Warnf("account %s: Google Tasks unavailable, syncing calendars only: %v", p.account.ID, taskErr)
 		return cals, nil
 	case taskErr != nil:
 		return nil, fmt.Errorf("list google task lists: %w", classifyAuthErr(taskErr))
@@ -120,6 +120,25 @@ func isServiceDisabled(err error) bool {
 	}
 	return strings.Contains(apiErr.Message, "has not been used in project") ||
 		strings.Contains(apiErr.Message, "it is disabled")
+}
+
+// isOptionalServiceUnavailable identifies failures that should disable Google
+// Tasks without blocking Calendar. Older account tokens lack the Tasks scope
+// because it was added after Calendar support shipped.
+func isOptionalServiceUnavailable(err error) bool {
+	if isServiceDisabled(err) {
+		return true
+	}
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) || apiErr.Code != http.StatusForbidden {
+		return false
+	}
+	for _, e := range apiErr.Errors {
+		if e.Reason == "insufficientPermissions" {
+			return true
+		}
+	}
+	return strings.Contains(strings.ToLower(apiErr.Message), "insufficient authentication scopes")
 }
 
 func (p *Provider) Sync(ctx context.Context, c cal.Calendar, cursor cal.SyncCursor) (*cal.SyncResult, error) {

--- a/core/internal/providers/google/provider_test.go
+++ b/core/internal/providers/google/provider_test.go
@@ -55,3 +55,45 @@ func TestIsServiceDisabled(t *testing.T) {
 		})
 	}
 }
+
+func TestIsOptionalServiceUnavailable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "service disabled",
+			err:  &googleapi.Error{Code: http.StatusForbidden, Errors: []googleapi.ErrorItem{{Reason: "accessNotConfigured"}}},
+			want: true,
+		},
+		{
+			name: "missing scope reason",
+			err:  &googleapi.Error{Code: http.StatusForbidden, Errors: []googleapi.ErrorItem{{Reason: "insufficientPermissions"}}},
+			want: true,
+		},
+		{
+			name: "wrapped missing scope message",
+			err:  fmt.Errorf("list task lists: %w", &googleapi.Error{Code: http.StatusForbidden, Message: "Request had insufficient authentication scopes."}),
+			want: true,
+		},
+		{
+			name: "another forbidden error",
+			err:  &googleapi.Error{Code: http.StatusForbidden, Errors: []googleapi.ErrorItem{{Reason: "rateLimitExceeded"}}},
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isOptionalServiceUnavailable(tc.err); got != tc.want {
+				t.Fatalf("isOptionalServiceUnavailable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/core/repo/migrate_test.go
+++ b/core/repo/migrate_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pressly/goose/v3"
 	_ "modernc.org/sqlite"
 )
 
@@ -96,5 +97,39 @@ func TestMigrateIsIdempotent(t *testing.T) {
 		if err := migrate(ctx, db); err != nil {
 			t.Fatalf("migrate run %d: %v", i, err)
 		}
+	}
+}
+
+func TestMeetingURLMigrationInvalidatesSyncTokens(t *testing.T) {
+	ctx := context.Background()
+	db, _ := openRaw(t, "meeting-urls.db")
+	defer db.Close()
+
+	configureGoose()
+	const previousVersion = 20260629125249
+	if err := goose.UpToContext(ctx, db, migrationsDir, previousVersion); err != nil {
+		t.Fatalf("migrate to previous version: %v", err)
+	}
+
+	_, err := db.ExecContext(ctx, `INSERT INTO accounts
+		(id, kind, display_name, created_at, updated_at)
+		VALUES ('account-1', 'google', 'Test', '2026-01-01', '2026-01-01');
+		INSERT INTO calendars
+		(id, remote_id, name, sync_token, created_at, updated_at, account_calendars)
+		VALUES ('calendar-1', 'remote-1', 'Test', 'cursor-1', '2026-01-01', '2026-01-01', 'account-1');`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrate(ctx, db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	var token sql.NullString
+	if err := db.QueryRowContext(ctx, "SELECT sync_token FROM calendars WHERE id = 'calendar-1';").Scan(&token); err != nil {
+		t.Fatal(err)
+	}
+	if token.Valid {
+		t.Fatalf("sync token was not invalidated: %q", token.String)
 	}
 }

--- a/quickshell/Modals/SettingsContent.qml
+++ b/quickshell/Modals/SettingsContent.qml
@@ -41,7 +41,7 @@ Item {
         switch (code) {
         case "tasks_unavailable":
             if (kind === "google")
-                return I18n.tr('Google Tasks API is disabled. <a href="https://console.cloud.google.com/apis/library/tasks.googleapis.com" style="text-decoration:none; color:%1;">Enable it</a>, then refresh, to sync tasks.', "account notice when the google tasks api is not enabled").arg(Theme.primary);
+                return I18n.tr('Google Tasks is unavailable. <a href="https://console.cloud.google.com/apis/library/tasks.googleapis.com" style="text-decoration:none; color:%1;">Enable its API</a> or reconnect this account, then refresh, to sync tasks.', 'account notice when google tasks is disabled or its permission is missing').arg(Theme.primary);
             if (kind === "microsoft")
                 return I18n.tr("Microsoft To Do access wasn't granted. Reconnect this account to sync tasks.", "account notice when microsoft to do permission is missing");
             return I18n.tr("Task lists couldn't be loaded; calendars are still syncing.", "account notice when task lists are unavailable but calendars sync");

--- a/quickshell/translations/en.json
+++ b/quickshell/translations/en.json
@@ -2,13 +2,13 @@
   {
     "term": "%1 AM",
     "context": "%1 AM",
-    "reference": "Modules/views/WeekView.qml:49, Modules/views/DayView.qml:50",
+    "reference": "Modules/views/DayView.qml:50, Modules/views/WeekView.qml:49",
     "comment": "morning hour label in time gutter"
   },
   {
     "term": "%1 PM",
     "context": "%1 PM",
-    "reference": "Modules/views/WeekView.qml:49, Modules/views/DayView.qml:50",
+    "reference": "Modules/views/DayView.qml:50, Modules/views/WeekView.qml:49",
     "comment": "afternoon hour label in time gutter"
   },
   {
@@ -74,7 +74,7 @@
   {
     "term": "1 day before",
     "context": "1 day before",
-    "reference": "Modals/SettingsContent.qml:173, Modals/EventDetailsModal.qml:66, Modals/CalendarRemindersDialog.qml:81",
+    "reference": "Modals/EventDetailsModal.qml:66, Modals/SettingsContent.qml:173, Modals/CalendarRemindersDialog.qml:81",
     "comment": "all-day reminder day dropdown option | event reminder dropdown option"
   },
   {
@@ -86,7 +86,7 @@
   {
     "term": "1 hour before",
     "context": "1 hour before",
-    "reference": "Modals/SettingsContent.qml:143, Modals/EventDetailsModal.qml:58, Modals/CalendarRemindersDialog.qml:53",
+    "reference": "Modals/EventDetailsModal.qml:58, Modals/SettingsContent.qml:143, Modals/CalendarRemindersDialog.qml:53",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -104,7 +104,7 @@
   {
     "term": "1 week before",
     "context": "1 week before",
-    "reference": "Modals/SettingsContent.qml:181, Modals/EventDetailsModal.qml:74, Modals/CalendarRemindersDialog.qml:89",
+    "reference": "Modals/EventDetailsModal.qml:74, Modals/SettingsContent.qml:181, Modals/CalendarRemindersDialog.qml:89",
     "comment": "all-day reminder day dropdown option | event reminder dropdown option"
   },
   {
@@ -122,7 +122,7 @@
   {
     "term": "10 minutes before",
     "context": "10 minutes before",
-    "reference": "Modals/SettingsContent.qml:131, Modals/EventDetailsModal.qml:46, Modals/CalendarRemindersDialog.qml:41",
+    "reference": "Modals/EventDetailsModal.qml:46, Modals/SettingsContent.qml:131, Modals/CalendarRemindersDialog.qml:41",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -146,13 +146,13 @@
   {
     "term": "15 minutes before",
     "context": "15 minutes before",
-    "reference": "Modals/SettingsContent.qml:135, Modals/EventDetailsModal.qml:50, Modals/CalendarRemindersDialog.qml:45",
+    "reference": "Modals/EventDetailsModal.qml:50, Modals/SettingsContent.qml:135, Modals/CalendarRemindersDialog.qml:45",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
     "term": "2 days before",
     "context": "2 days before",
-    "reference": "Modals/SettingsContent.qml:177, Modals/EventDetailsModal.qml:70, Modals/CalendarRemindersDialog.qml:85",
+    "reference": "Modals/EventDetailsModal.qml:70, Modals/SettingsContent.qml:177, Modals/CalendarRemindersDialog.qml:85",
     "comment": "all-day reminder day dropdown option | event reminder dropdown option"
   },
   {
@@ -200,7 +200,7 @@
   {
     "term": "30 minutes before",
     "context": "30 minutes before",
-    "reference": "Modals/SettingsContent.qml:139, Modals/EventDetailsModal.qml:54, Modals/CalendarRemindersDialog.qml:49",
+    "reference": "Modals/EventDetailsModal.qml:54, Modals/SettingsContent.qml:139, Modals/CalendarRemindersDialog.qml:49",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -218,7 +218,7 @@
   {
     "term": "5 minutes before",
     "context": "5 minutes before",
-    "reference": "Modals/SettingsContent.qml:127, Modals/EventDetailsModal.qml:42, Modals/CalendarRemindersDialog.qml:37",
+    "reference": "Modals/EventDetailsModal.qml:42, Modals/SettingsContent.qml:127, Modals/CalendarRemindersDialog.qml:37",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -272,7 +272,7 @@
   {
     "term": "Accounts",
     "context": "Accounts",
-    "reference": "Modals/SettingsContent.qml:1014, Modals/SettingsSidebar.qml:27, Modules/CalendarSidebar.qml:498",
+    "reference": "Modules/CalendarSidebar.qml:498, Modals/SettingsSidebar.qml:27, Modals/SettingsContent.qml:1014",
     "comment": "accounts settings section header | settings sidebar tab label | sidebar section header for the account list"
   },
   {
@@ -296,7 +296,7 @@
   {
     "term": "Add account",
     "context": "Add account",
-    "reference": "Modals/SettingsContent.qml:1152, Modals/AccountAddModal.qml:213, Modals/AccountAddModal.qml:305, Modules/CalendarSidebar.qml:641",
+    "reference": "Modules/CalendarSidebar.qml:641, Modals/AccountAddModal.qml:213, Modals/AccountAddModal.qml:305, Modals/SettingsContent.qml:1152",
     "comment": "account add modal header title | account add modal window title | add account button on accounts page | sidebar button to add a provider account"
   },
   {
@@ -332,7 +332,7 @@
   {
     "term": "Agenda",
     "context": "Agenda",
-    "reference": "Modules/CalendarContent.qml:35, Modules/CalendarSidebar.qml:154",
+    "reference": "Modules/CalendarSidebar.qml:154, Modules/CalendarContent.qml:35",
     "comment": "header title when the agenda view is active | view switcher option in sidebar"
   },
   {
@@ -350,7 +350,7 @@
   {
     "term": "All day",
     "context": "All day",
-    "reference": "Modals/EventDetailsModal.qml:929, Modals/SearchModal.qml:80, Modules/views/MonthDayPopover.qml:157, Modules/views/AgendaView.qml:60, Modules/views/MonthView.qml:98, Modules/views/WeekView.qml:65, Modules/views/DayView.qml:40",
+    "reference": "Modals/EventDetailsModal.qml:929, Modals/SearchModal.qml:80, Modules/views/AgendaView.qml:60, Modules/views/DayView.qml:40, Modules/views/WeekView.qml:65, Modules/views/MonthView.qml:98, Modules/views/MonthDayPopover.qml:157",
     "comment": "all-day marker in event tooltip | all-day marker in the month day-detail popover | event form toggle label for all-day events | search result subtitle for all-day events | time column label for all-day events on agenda card"
   },
   {
@@ -398,7 +398,7 @@
   {
     "term": "Appearance",
     "context": "Appearance",
-    "reference": "Modals/SettingsContent.qml:552, Modals/SettingsSidebar.qml:19",
+    "reference": "Modals/SettingsSidebar.qml:19, Modals/SettingsContent.qml:552",
     "comment": "appearance settings section header | settings sidebar tab label"
   },
   {
@@ -428,7 +428,7 @@
   {
     "term": "At start",
     "context": "At start",
-    "reference": "Modals/SettingsContent.qml:123, Modals/EventDetailsModal.qml:38, Modals/EventDetailsModal.qml:169, Modals/CalendarRemindersDialog.qml:33",
+    "reference": "Modals/EventDetailsModal.qml:38, Modals/EventDetailsModal.qml:169, Modals/SettingsContent.qml:123, Modals/CalendarRemindersDialog.qml:33",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -506,7 +506,7 @@
   {
     "term": "Calendars",
     "context": "Calendars",
-    "reference": "Modals/SettingsContent.qml:818, Modals/SettingsSidebar.qml:23",
+    "reference": "Modals/SettingsSidebar.qml:23, Modals/SettingsContent.qml:818",
     "comment": "calendars settings section header | settings sidebar tab label"
   },
   {
@@ -518,7 +518,7 @@
   {
     "term": "Cancel",
     "context": "Cancel",
-    "reference": "Modals/AccountAddModal.qml:1096, Modals/NewCalendarDialog.qml:100, Modals/EventDetailsModal.qml:523, Modals/RenameCalendarDialog.qml:97, Modals/CalendarRemindersDialog.qml:375, Modals/ConfirmDialog.qml:71, Modals/TaskDetailsModal.qml:497, Modals/FileBrowser/FileBrowserOverwriteDialog.qml:83",
+    "reference": "Modals/ConfirmDialog.qml:71, Modals/EventDetailsModal.qml:523, Modals/NewCalendarDialog.qml:100, Modals/RenameCalendarDialog.qml:97, Modals/TaskDetailsModal.qml:497, Modals/AccountAddModal.qml:1096, Modals/CalendarRemindersDialog.qml:375, Modals/FileBrowser/FileBrowserOverwriteDialog.qml:83",
     "comment": "button to cancel oauth browser step | confirm dialog button to cancel | event form button to cancel editing | file browser overwrite dialog cancel button | new calendar dialog button to cancel | per-calendar reminders dialog button to cancel | rename calendar dialog button to cancel | task form button to discard changes"
   },
   {
@@ -620,7 +620,7 @@
   {
     "term": "Connected",
     "context": "Connected",
-    "reference": "Modals/SettingsContent.qml:1090, Modals/AccountAddModal.qml:1138, Modals/SettingsAboutPage.qml:365",
+    "reference": "Modals/AccountAddModal.qml:1138, Modals/SettingsContent.qml:1090, Modals/SettingsAboutPage.qml:365",
     "comment": "about page daemon status value | account status in account list | success step status heading"
   },
   {
@@ -686,7 +686,7 @@
   {
     "term": "Create event",
     "context": "Create event",
-    "reference": "Modals/KeyboardShortcutsOverlay.qml:78, Modules/CalendarSidebar.qml:121",
+    "reference": "Modules/CalendarSidebar.qml:121, Modals/KeyboardShortcutsOverlay.qml:78",
     "comment": "keyboard shortcut description | sidebar button to create a new event"
   },
   {
@@ -776,13 +776,13 @@
   {
     "term": "Delete",
     "context": "Delete",
-    "reference": "Modals/SettingsContent.qml:920, Modals/TaskDetailsModal.qml:487, Modules/CalendarSidebar.qml:694",
+    "reference": "Modules/CalendarSidebar.qml:694, Modals/TaskDetailsModal.qml:487, Modals/SettingsContent.qml:920",
     "comment": "confirm button for deleting a calendar | delete calendar confirmation button | task form button to delete the task"
   },
   {
     "term": "Delete \"%1\"?",
     "context": "Delete \"%1\"?",
-    "reference": "Modals/SettingsContent.qml:918, Modules/CalendarSidebar.qml:692",
+    "reference": "Modules/CalendarSidebar.qml:692, Modals/SettingsContent.qml:918",
     "comment": "confirm dialog title for deleting a calendar, %1 is the calendar name | delete calendar confirmation title"
   },
   {
@@ -1004,7 +1004,7 @@
   {
     "term": "General",
     "context": "General",
-    "reference": "Modals/SettingsContent.qml:350, Modals/KeyboardShortcutsOverlay.qml:74, Modals/SettingsSidebar.qml:15",
+    "reference": "Modals/SettingsSidebar.qml:15, Modals/SettingsContent.qml:350, Modals/KeyboardShortcutsOverlay.qml:74",
     "comment": "general settings section header | keyboard shortcuts overlay section header | settings sidebar tab label"
   },
   {
@@ -1024,6 +1024,12 @@
     "context": "Go to today",
     "reference": "Modals/KeyboardShortcutsOverlay.qml:16",
     "comment": "keyboard shortcut description"
+  },
+  {
+    "term": "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.",
+    "context": "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.",
+    "reference": "Modals/SettingsContent.qml:44",
+    "comment": "account notice when google tasks is disabled or its permission is missing"
   },
   {
     "term": "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.",
@@ -1148,7 +1154,7 @@
   {
     "term": "Local",
     "context": "Local",
-    "reference": "Modals/SettingsContent.qml:995, Modals/AccountAddModal.qml:120, Modals/AccountAddModal.qml:511, Services/DankCalService.qml:1343",
+    "reference": "Modals/AccountAddModal.qml:120, Modals/AccountAddModal.qml:511, Modals/SettingsContent.qml:995, Services/DankCalService.qml:1343",
     "comment": "local provider name in account add modal | local provider name in account list | provider label for a local account"
   },
   {
@@ -1406,7 +1412,7 @@
   {
     "term": "None",
     "context": "None",
-    "reference": "Modals/SettingsContent.qml:119, Modals/EventDetailsModal.qml:34, Modals/CalendarRemindersDialog.qml:29, Modals/TaskDetailsModal.qml:66",
+    "reference": "Modals/EventDetailsModal.qml:34, Modals/TaskDetailsModal.qml:66, Modals/SettingsContent.qml:119, Modals/CalendarRemindersDialog.qml:29",
     "comment": "default reminder dropdown option | event reminder dropdown option | task priority dropdown option"
   },
   {
@@ -1436,7 +1442,7 @@
   {
     "term": "Notifications",
     "context": "Notifications",
-    "reference": "Modals/SettingsContent.qml:1186, Modals/SettingsSidebar.qml:31",
+    "reference": "Modals/SettingsSidebar.qml:31, Modals/SettingsContent.qml:1186",
     "comment": "notifications settings section header | settings sidebar tab label"
   },
   {
@@ -1622,7 +1628,7 @@
   {
     "term": "Quit",
     "context": "Quit",
-    "reference": "Modals/SettingsContent.qml:378, Modules/TrayIcon.qml:57",
+    "reference": "Modules/TrayIcon.qml:57, Modals/SettingsContent.qml:378",
     "comment": "close behavior button group option to quit the app | tray menu item to quit the application"
   },
   {
@@ -1664,25 +1670,25 @@
   {
     "term": "Remove",
     "context": "Remove",
-    "reference": "Modals/SettingsContent.qml:1141, Modules/CalendarSidebar.qml:779",
+    "reference": "Modules/CalendarSidebar.qml:779, Modals/SettingsContent.qml:1141",
     "comment": "confirm button for removing an account | remove account confirmation button"
   },
   {
     "term": "Remove \"%1\"?",
     "context": "Remove \"%1\"?",
-    "reference": "Modals/SettingsContent.qml:1139, Modules/CalendarSidebar.qml:777",
+    "reference": "Modules/CalendarSidebar.qml:777, Modals/SettingsContent.qml:1139",
     "comment": "confirm dialog title for removing an account, %1 is the account label | remove account confirmation title"
   },
   {
     "term": "Removes this account and its calendars and events from Dank Calendar. Nothing is deleted from the provider.",
     "context": "Removes this account and its calendars and events from Dank Calendar. Nothing is deleted from the provider.",
-    "reference": "Modals/SettingsContent.qml:1140, Modules/CalendarSidebar.qml:778",
+    "reference": "Modules/CalendarSidebar.qml:778, Modals/SettingsContent.qml:1140",
     "comment": "confirm dialog body for removing an account | remove account confirmation message"
   },
   {
     "term": "Removes this calendar and its events from Dank Calendar. If the provider still offers it, it will come back on the next sync.",
     "context": "Removes this calendar and its events from Dank Calendar. If the provider still offers it, it will come back on the next sync.",
-    "reference": "Modals/SettingsContent.qml:919, Modules/CalendarSidebar.qml:693",
+    "reference": "Modules/CalendarSidebar.qml:693, Modals/SettingsContent.qml:919",
     "comment": "confirm dialog body for deleting a calendar | delete calendar confirmation message"
   },
   {
@@ -1736,7 +1742,7 @@
   {
     "term": "Save",
     "context": "Save",
-    "reference": "Modals/EventDetailsModal.qml:537, Modals/RenameCalendarDialog.qml:104, Modals/CalendarRemindersDialog.qml:382, Modals/TaskDetailsModal.qml:506, Modals/FileBrowser/FileBrowserSaveRow.qml:59",
+    "reference": "Modals/EventDetailsModal.qml:537, Modals/RenameCalendarDialog.qml:104, Modals/TaskDetailsModal.qml:506, Modals/CalendarRemindersDialog.qml:382, Modals/FileBrowser/FileBrowserSaveRow.qml:59",
     "comment": "event details button to save changes | file browser save button | per-calendar reminders dialog button to save | rename calendar dialog button to save name | task form button to persist the task"
   },
   {
@@ -1808,7 +1814,7 @@
   {
     "term": "Settings",
     "context": "Settings",
-    "reference": "Modals/KeyboardShortcutsOverlay.qml:86, Modals/SettingsModal.qml:86",
+    "reference": "Modals/SettingsModal.qml:86, Modals/KeyboardShortcutsOverlay.qml:86",
     "comment": "keyboard shortcut description | settings window header title"
   },
   {
@@ -2000,7 +2006,7 @@
   {
     "term": "Tasks",
     "context": "Tasks",
-    "reference": "Modules/CalendarContent.qml:37, Modules/CalendarSidebar.qml:161, Modules/CalendarSidebar.qml:374",
+    "reference": "Modules/CalendarSidebar.qml:161, Modules/CalendarSidebar.qml:374, Modules/CalendarContent.qml:37",
     "comment": "header title when the tasks view is active | sidebar section header for the task list | view switcher option in sidebar"
   },
   {
@@ -2048,7 +2054,7 @@
   {
     "term": "Today",
     "context": "Today",
-    "reference": "Modals/SearchModal.qml:69, Modules/CalendarContent.qml:58, Modules/views/AgendaView.qml:29, Modules/views/TasksView.qml:31, Modules/views/TasksView.qml:52",
+    "reference": "Modules/CalendarContent.qml:58, Modals/SearchModal.qml:69, Modules/views/AgendaView.qml:29, Modules/views/TasksView.qml:31, Modules/views/TasksView.qml:52",
     "comment": "agenda section header for the current day | due-date label on a task card | header button that jumps to the current date | search result date label for current day | tasks view section header for tasks due today"
   },
   {

--- a/quickshell/translations/poexports/ar.json
+++ b/quickshell/translations/poexports/ar.json
@@ -44,6 +44,9 @@
   "1 hour before": {
     "1 hour before": "قبل ساعة"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
     "1 minute": ""
   },
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "قبل ٢ ساعة"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "٢٤ ساعة"
   },
   "24h": {
     "24h": "٢٤س"
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "٣٠ دقيقة"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "الانتقال إلى اليوم"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "تطلب Google منك إنشاء عميل OAuth الخاص بك لقراءة بيانات التقويم نيابة عنك. هذا الإعداد لمرة واحدة فقط ويستغرق حوالي ثلاث دقائق."
   },
@@ -590,6 +602,12 @@
   "Marked as not done": {
     "Marked as not done": ""
   },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
+  },
   "Maybe": {
     "Maybe": ""
   },
@@ -613,6 +631,9 @@
   },
   "Month": {
     "Month": "الشهر"
+  },
+  "Month event title lines": {
+    "Month event title lines": ""
   },
   "Month view": {
     "Month view": "عرض الشهر"
@@ -995,6 +1016,9 @@
   "Tasks": {
     "Tasks": ""
   },
+  "Tasks view": {
+    "Tasks view": ""
+  },
   "Test notification": {
     "Test notification": "إشعار تجريبي"
   },
@@ -1087,6 +1111,9 @@
   },
   "Week": {
     "Week": "الأسبوع"
+  },
+  "Week event title lines": {
+    "Week event title lines": ""
   },
   "Week view": {
     "Week view": "عرض الأسبوع"

--- a/quickshell/translations/poexports/de.json
+++ b/quickshell/translations/poexports/de.json
@@ -44,8 +44,11 @@
   "1 hour before": {
     "1 hour before": "1 Stunde vorher"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
-    "1 minute": ""
+    "1 minute": "1 Minute"
   },
   "1 week before": {
     "1 week before": "1 Woche vorher"
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "2 Stunden vorher"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24-Stunden"
   },
   "24h": {
     "24h": "24 Std."
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30 Minuten"
@@ -117,7 +126,7 @@
     "About": "Über"
   },
   "Accept": {
-    "Accept": ""
+    "Accept": "Akzeptieren"
   },
   "Account connected": {
     "Account connected": "Konto verbunden"
@@ -132,7 +141,7 @@
     "Add": "Hinzufügen"
   },
   "Add a CalDAV, local, Google, or Microsoft account with a task list to create tasks.": {
-    "Add a CalDAV, local, Google, or Microsoft account with a task list to create tasks.": ""
+    "Add a CalDAV, local, Google, or Microsoft account with a task list to create tasks.": "Füge ein CalDAV-, lokales, Google- oder Microsoft-Konto mit einer Aufgabenliste hinzu, um Aufgaben zu erstellen."
   },
   "Add a calendar": {
     "Add a calendar": "Einen Kalender hinzufügen"
@@ -144,7 +153,7 @@
     "Add description": "Beschreibung hinzufügen"
   },
   "Add task": {
-    "Add task": ""
+    "Add task": "Aufgabe hinzufügen"
   },
   "Add title": {
     "Add title": "Titel hinzufügen"
@@ -168,7 +177,7 @@
     "All day": "Ganztägig"
   },
   "All done": {
-    "All done": ""
+    "All done": "Alles erledigt"
   },
   "All-day reminder time": {
     "All-day reminder time": "Erinnerungszeit für ganztägige Termine"
@@ -246,7 +255,7 @@
     "Calendars": "Kalender"
   },
   "Calendars couldn't be loaded; tasks are still syncing.": {
-    "Calendars couldn't be loaded; tasks are still syncing.": ""
+    "Calendars couldn't be loaded; tasks are still syncing.": "Kalender konnten nicht geladen werden; Aufgaben werden noch synchronisiert."
   },
   "Cancel": {
     "Cancel": "Abbrechen"
@@ -285,7 +294,7 @@
     "Coming soon": "Demnächst"
   },
   "Completed": {
-    "Completed": ""
+    "Completed": "Abgeschlossen"
   },
   "Confirm": {
     "Confirm": "Bestätigen"
@@ -315,7 +324,7 @@
     "Continue": "Weiter"
   },
   "Copied to clipboard": {
-    "Copied to clipboard": ""
+    "Copied to clipboard": "In Zwischenablage kopiert"
   },
   "Copy link": {
     "Copy link": "Link kopieren"
@@ -330,7 +339,7 @@
     "Could not read that file.": "Datei konnte nicht gelesen werden."
   },
   "Couldn't update task": {
-    "Couldn't update task": ""
+    "Couldn't update task": "Aufgabe konnte nicht aktualisiert werden"
   },
   "Create": {
     "Create": "Erstellen"
@@ -354,7 +363,7 @@
     "Daemon offline": "Daemon offline"
   },
   "Daily": {
-    "Daily": ""
+    "Daily": "Täglich"
   },
   "Dank Calendar is a calendar for the modern Linux desktop with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design, plus a hackable CLI and socket API for integrations.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": {
     "Dank Calendar is a calendar for the modern Linux desktop with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design, plus a hackable CLI and socket API for integrations.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": "Dank Calendar ist ein Kalender für den modernen Linux-Desktop mit einem <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">Material 3 inspirierten</a> Design, sowie einer hackbaren CLI und Socket-API für Integrationen.<br /><br/>Er wurde mit <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, einem QT6-Framework zum Erstellen von Desktop-Shells, und <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, einer statisch typisierten, kompilierten Programmiersprache, entwickelt."
@@ -375,7 +384,7 @@
     "Day view": "Tagesansicht"
   },
   "Decline": {
-    "Decline": ""
+    "Decline": "Ablehnen"
   },
   "Default event duration": {
     "Default event duration": "Standard-Termindauer"
@@ -423,7 +432,7 @@
     "Documents": "Dokumente"
   },
   "Does not repeat": {
-    "Does not repeat": ""
+    "Does not repeat": "Wiederholt sich nicht"
   },
   "Done": {
     "Done": "Fertig"
@@ -435,13 +444,13 @@
     "Drag to pan · click to fit": "Ziehen zum Schwenken · Klicken zum Einpassen"
   },
   "Due date": {
-    "Due date": ""
+    "Due date": "Fälligkeitsdatum"
   },
   "Edit event": {
     "Edit event": "Termin bearbeiten"
   },
   "Edit task": {
-    "Edit task": ""
+    "Edit task": "Aufgabe bearbeiten"
   },
   "Enable reminders": {
     "Enable reminders": "Erinnerungen aktivieren"
@@ -471,7 +480,7 @@
     "Event details": "Termindetails"
   },
   "Every": {
-    "Every": ""
+    "Every": "Alle"
   },
   "Evolution": {
     "Evolution": "Evolution"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "Heute"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google erfordert, dass Sie einen eigenen OAuth-Client erstellen, um Kalenderdaten in Ihrem Namen zu lesen. Dies ist eine einmalige Einrichtung, die etwa drei Minuten dauert."
   },
@@ -519,7 +531,7 @@
     "Hide": "Ausblenden"
   },
   "High": {
-    "High": ""
+    "High": "Hoch"
   },
   "Home": {
     "Home": "Persönlicher Ordner"
@@ -528,7 +540,7 @@
     "How long the snooze button postpones a reminder.": "Wie lange die Schlummertaste eine Erinnerung verschiebt."
   },
   "How often accounts are polled for changes.": {
-    "How often accounts are polled for changes.": ""
+    "How often accounts are polled for changes.": "Wie oft Konten auf Änderungen abgefragt werden."
   },
   "Import client_secret.json": {
     "Import client_secret.json": "client_secret.json importieren"
@@ -564,7 +576,7 @@
     "Light": "Hell"
   },
   "List": {
-    "List": ""
+    "List": "Liste"
   },
   "Load colors from your own theme file.": {
     "Load colors from your own theme file.": "Farben aus eigener Themendatei laden."
@@ -585,19 +597,25 @@
     "Location": "Ort"
   },
   "Low": {
-    "Low": ""
+    "Low": "Niedrig"
   },
   "Marked as not done": {
-    "Marked as not done": ""
+    "Marked as not done": "Als nicht erledigt markiert"
+  },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
   },
   "Maybe": {
-    "Maybe": ""
+    "Maybe": "Vielleicht"
   },
   "Medium": {
-    "Medium": ""
+    "Medium": "Mittel"
   },
   "Microsoft To Do access wasn't granted. Reconnect this account to sync tasks.": {
-    "Microsoft To Do access wasn't granted. Reconnect this account to sync tasks.": ""
+    "Microsoft To Do access wasn't granted. Reconnect this account to sync tasks.": "Zugriff auf Microsoft To Do wurde nicht gewährt. Verbinde dieses Konto erneut, um Aufgaben zu synchronisieren."
   },
   "Microsoft often returns server_error for the first few minutes after an app registration is created or changed. Wait a minute or two and try again.": {
     "Microsoft often returns server_error for the first few minutes after an app registration is created or changed. Wait a minute or two and try again.": "Microsoft gibt in den ersten Minuten nach dem Erstellen oder Ändern einer App-Registrierung häufig einen server_error zurück. Warten Sie ein oder zwei Minuten und versuchen Sie es erneut."
@@ -614,11 +632,14 @@
   "Month": {
     "Month": "Monat"
   },
+  "Month event title lines": {
+    "Month event title lines": ""
+  },
   "Month view": {
     "Month view": "Monatsansicht"
   },
   "Monthly": {
-    "Monthly": ""
+    "Monthly": "Monatlich"
   },
   "Move to Trash": {
     "Move to Trash": "In den Papierkorb verschieben"
@@ -648,7 +669,7 @@
     "New event": "Neues Ereignis"
   },
   "New task": {
-    "New task": ""
+    "New task": "Neue Aufgabe"
   },
   "Next day": {
     "Next day": "Nächster Tag"
@@ -675,16 +696,16 @@
     "No calendars yet. Add one to start creating events.": "Noch keine Kalender vorhanden. Fügen Sie einen hinzu, um Ereignisse zu erstellen."
   },
   "No due date": {
-    "No due date": ""
+    "No due date": "Kein Fälligkeitsdatum"
   },
   "No matching events": {
     "No matching events": "Keine passenden Ereignisse"
   },
   "No task list available": {
-    "No task list available": ""
+    "No task list available": "Keine Aufgabenliste verfügbar"
   },
   "No tasks yet": {
-    "No tasks yet": ""
+    "No tasks yet": "Noch keine Aufgaben"
   },
   "No theme file selected": {
     "No theme file selected": "Keine Themendatei ausgewählt"
@@ -702,7 +723,7 @@
     "Not signed in — click to reconnect or re-add this account": "Nicht angemeldet — klicken, um die Verbindung wiederherzustellen oder dieses Konto erneut hinzuzufügen"
   },
   "Notes": {
-    "Notes": ""
+    "Notes": "Notizen"
   },
   "Nothing scheduled in the next %1 days": {
     "Nothing scheduled in the next %1 days": "Nichts geplant in den nächsten %1 Tagen"
@@ -738,7 +759,7 @@
     "Outlook, Office 365 and Exchange Online calendars.": "Outlook-, Office 365- und Exchange Online-Kalender."
   },
   "Overdue": {
-    "Overdue": ""
+    "Overdue": "Überfällig"
   },
   "Override": {
     "Override": "Überschreiben"
@@ -795,7 +816,7 @@
     "Previous week": "Vorherige Woche"
   },
   "Priority": {
-    "Priority": ""
+    "Priority": "Priorität"
   },
   "Quick Access": {
     "Quick Access": "Schnellzugriff"
@@ -807,7 +828,7 @@
     "Reconnect": "Erneut verbinden"
   },
   "Recurring tasks are managed in Google Tasks.": {
-    "Recurring tasks are managed in Google Tasks.": ""
+    "Recurring tasks are managed in Google Tasks.": "Wiederkehrende Aufgaben werden in Google Tasks verwaltet."
   },
   "Reminders and desktop alerts.": {
     "Reminders and desktop alerts.": "Erinnerungen und Desktop-Benachrichtigungen."
@@ -843,16 +864,16 @@
     "Rename…": "Umbenennen …"
   },
   "Repeat": {
-    "Repeat": ""
+    "Repeat": "Wiederholen"
   },
   "Repeats": {
-    "Repeats": ""
+    "Repeats": "Wiederholungen"
   },
   "Repeats every %1": {
-    "Repeats every %1": ""
+    "Repeats every %1": "Wiederholt sich alle %1"
   },
   "Repeats every %1 %2": {
-    "Repeats every %1 %2": ""
+    "Repeats every %1 %2": "Wiederholt sich alle %1 %2"
   },
   "Reset to global": {
     "Reset to global": "Auf global zurücksetzen"
@@ -903,10 +924,10 @@
     "Show all-day reminders": "Ganztägige Erinnerungen anzeigen"
   },
   "Show task lists and the Tasks view when an account provides them.": {
-    "Show task lists and the Tasks view when an account provides them.": ""
+    "Show task lists and the Tasks view when an account provides them.": "Aufgabenlisten und die Aufgabenansicht anzeigen, wenn ein Konto diese bereitstellt."
   },
   "Show tasks": {
-    "Show tasks": ""
+    "Show tasks": "Aufgaben anzeigen"
   },
   "Show week numbers": {
     "Show week numbers": "Wochennummern anzeigen"
@@ -966,7 +987,7 @@
     "Subscribing…": "Abonnieren…"
   },
   "Sync interval": {
-    "Sync interval": ""
+    "Sync interval": "Synchronisierungsintervall"
   },
   "Sync now": {
     "Sync now": "Jetzt synchronisieren"
@@ -984,16 +1005,19 @@
     "Tab/Shift+Tab: Nav • ←→↑↓: Grid Nav • Enter/Space: Select": "Tab/Umschalt+Tab: Nav • ←→↑↓: Gitter-Nav • Eingabe/Leertaste: Auswählen"
   },
   "Task": {
-    "Task": ""
+    "Task": "Aufgabe"
   },
   "Task completed": {
-    "Task completed": ""
+    "Task completed": "Aufgabe abgeschlossen"
   },
   "Task lists couldn't be loaded; calendars are still syncing.": {
-    "Task lists couldn't be loaded; calendars are still syncing.": ""
+    "Task lists couldn't be loaded; calendars are still syncing.": "Aufgabenlisten konnten nicht geladen werden; Kalender werden noch synchronisiert."
   },
   "Tasks": {
-    "Tasks": ""
+    "Tasks": "Aufgaben"
+  },
+  "Tasks view": {
+    "Tasks view": ""
   },
   "Test notification": {
     "Test notification": "Testbenachrichtigung"
@@ -1035,13 +1059,13 @@
     "Type at least 2 characters to search events.": "Geben Sie mindestens 2 Zeichen ein, um nach Ereignissen zu suchen."
   },
   "Undo": {
-    "Undo": ""
+    "Undo": "Rückgängig machen"
   },
   "University timetable": {
     "University timetable": "Stundenplan der Universität"
   },
   "Upcoming": {
-    "Upcoming": ""
+    "Upcoming": "Anstehend"
   },
   "Use a bundled color palette.": {
     "Use a bundled color palette.": "Verwenden Sie eine mitgelieferte Farbpalette."
@@ -1088,11 +1112,14 @@
   "Week": {
     "Week": "Woche"
   },
+  "Week event title lines": {
+    "Week event title lines": ""
+  },
   "Week view": {
     "Week view": "Wochenansicht"
   },
   "Weekly": {
-    "Weekly": ""
+    "Weekly": "Wöchentlich"
   },
   "What the window's close button does.": {
     "What the window's close button does.": "Was die Schließen-Schaltfläche des Fensters bewirkt."
@@ -1101,7 +1128,7 @@
     "When all-day event reminders fire.": "Wann Erinnerungen für ganztägige Ereignisse ausgelöst werden."
   },
   "Yearly": {
-    "Yearly": ""
+    "Yearly": "Jährlich"
   },
   "Yesterday": {
     "Yesterday": "Gestern"
@@ -1113,7 +1140,7 @@
     "Your client ID, secret, and refresh token are stored in the system keyring (libsecret/kwallet) when available, or an encrypted local file.": "Ihre Client-ID, Ihr Secret und Ihr Refresh-Token werden im System-Schlüsselbund (libsecret/kwallet), falls verfügbar, oder in einer verschlüsselten lokalen Datei gespeichert."
   },
   "Your response": {
-    "Your response": ""
+    "Your response": "Deine Antwort"
   },
   "all day": {
     "all day": "ganztägig"
@@ -1122,10 +1149,10 @@
     "dark": "dunkel"
   },
   "day": {
-    "day": ""
+    "day": "Tag"
   },
   "days": {
-    "days": ""
+    "days": "Tage"
   },
   "iCal subscription": {
     "iCal subscription": "iCal-Abonnement"
@@ -1134,10 +1161,10 @@
     "light": "hell"
   },
   "month": {
-    "month": ""
+    "month": "Monat"
   },
   "months": {
-    "months": ""
+    "months": "Monate"
   },
   "only if the feed requires sign-in": {
     "only if the feed requires sign-in": "nur wenn der Feed eine Anmeldung erfordert"
@@ -1155,16 +1182,16 @@
     "username": "Benutzername"
   },
   "week": {
-    "week": ""
+    "week": "Woche"
   },
   "weeks": {
-    "weeks": ""
+    "weeks": "Wochen"
   },
   "year": {
-    "year": ""
+    "year": "Jahr"
   },
   "years": {
-    "years": ""
+    "years": "Jahre"
   },
   "· %1 invited · %2 accepted": {
     "· %1 invited · %2 accepted": "· %1 eingeladen · %2 zugesagt"

--- a/quickshell/translations/poexports/es.json
+++ b/quickshell/translations/poexports/es.json
@@ -44,6 +44,9 @@
   "1 hour before": {
     "1 hour before": "1 hora antes"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
     "1 minute": ""
   },
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "2 horas antes"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24 horas"
   },
   "24h": {
     "24h": "24h"
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30 minutos"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "Ir a hoy"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google requiere que crees tu propio cliente OAuth para leer los datos del calendario en tu nombre. Solo hay que configurarlo una vez y se tarda unos tres minutos."
   },
@@ -590,6 +602,12 @@
   "Marked as not done": {
     "Marked as not done": ""
   },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
+  },
   "Maybe": {
     "Maybe": ""
   },
@@ -613,6 +631,9 @@
   },
   "Month": {
     "Month": "Mes"
+  },
+  "Month event title lines": {
+    "Month event title lines": ""
   },
   "Month view": {
     "Month view": "Vista de mes"
@@ -995,6 +1016,9 @@
   "Tasks": {
     "Tasks": ""
   },
+  "Tasks view": {
+    "Tasks view": ""
+  },
   "Test notification": {
     "Test notification": "Notificación de prueba"
   },
@@ -1087,6 +1111,9 @@
   },
   "Week": {
     "Week": "Semana"
+  },
+  "Week event title lines": {
+    "Week event title lines": ""
   },
   "Week view": {
     "Week view": "Vista semanal"

--- a/quickshell/translations/poexports/he.json
+++ b/quickshell/translations/poexports/he.json
@@ -44,6 +44,9 @@
   "1 hour before": {
     "1 hour before": "שעה אחת לפני"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
     "1 minute": ""
   },
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "שעתיים לפני"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24 שעות"
   },
   "24h": {
     "24h": "24h"
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30 דקות"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "מעבר להיום"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google דורשת ממך ליצור לקוח OAuth משלך כדי לקרוא נתוני יומן בשמך. זוהי הגדרה חד-פעמית שלוקחת כ-3 דקות."
   },
@@ -590,6 +602,12 @@
   "Marked as not done": {
     "Marked as not done": ""
   },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
+  },
   "Maybe": {
     "Maybe": ""
   },
@@ -613,6 +631,9 @@
   },
   "Month": {
     "Month": "חודש"
+  },
+  "Month event title lines": {
+    "Month event title lines": ""
   },
   "Month view": {
     "Month view": "תצוגת חודש"
@@ -995,6 +1016,9 @@
   "Tasks": {
     "Tasks": ""
   },
+  "Tasks view": {
+    "Tasks view": ""
+  },
   "Test notification": {
     "Test notification": "התראת בדיקה"
   },
@@ -1087,6 +1111,9 @@
   },
   "Week": {
     "Week": "שבוע"
+  },
+  "Week event title lines": {
+    "Week event title lines": ""
   },
   "Week view": {
     "Week view": "תצוגת שבוע"

--- a/quickshell/translations/poexports/it.json
+++ b/quickshell/translations/poexports/it.json
@@ -44,6 +44,9 @@
   "1 hour before": {
     "1 hour before": "1 ora prima"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
     "1 minute": ""
   },
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "2 ore prima"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24 ore"
   },
   "24h": {
     "24h": "24h"
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30 minuti"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "Vai a oggi"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google richiede di creare un proprio client OAuth per leggere i dati del calendario per tuo conto. Si tratta di una configurazione unica che richiede circa tre minuti."
   },
@@ -590,6 +602,12 @@
   "Marked as not done": {
     "Marked as not done": ""
   },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
+  },
   "Maybe": {
     "Maybe": ""
   },
@@ -613,6 +631,9 @@
   },
   "Month": {
     "Month": "Mese"
+  },
+  "Month event title lines": {
+    "Month event title lines": ""
   },
   "Month view": {
     "Month view": "Vista mese"
@@ -995,6 +1016,9 @@
   "Tasks": {
     "Tasks": ""
   },
+  "Tasks view": {
+    "Tasks view": ""
+  },
   "Test notification": {
     "Test notification": "Notifica di prova"
   },
@@ -1087,6 +1111,9 @@
   },
   "Week": {
     "Week": "Settimana"
+  },
+  "Week event title lines": {
+    "Week event title lines": ""
   },
   "Week view": {
     "Week view": "Vista settimana"

--- a/quickshell/translations/poexports/nl.json
+++ b/quickshell/translations/poexports/nl.json
@@ -44,6 +44,9 @@
   "1 hour before": {
     "1 hour before": "1 uur van tevoren"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
     "1 minute": ""
   },
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "2 uur van tevoren"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24-uurs"
   },
   "24h": {
     "24h": "24u"
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30 minuten"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "Ga naar vandaag"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google vereist dat je een eigen OAuth-client aanmaakt om agendagegevens namens jou te lezen. Dit is een eenmalige installatie die ongeveer drie minuten duurt."
   },
@@ -590,6 +602,12 @@
   "Marked as not done": {
     "Marked as not done": ""
   },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
+  },
   "Maybe": {
     "Maybe": ""
   },
@@ -613,6 +631,9 @@
   },
   "Month": {
     "Month": "Maand"
+  },
+  "Month event title lines": {
+    "Month event title lines": ""
   },
   "Month view": {
     "Month view": "Maandweergave"
@@ -995,6 +1016,9 @@
   "Tasks": {
     "Tasks": ""
   },
+  "Tasks view": {
+    "Tasks view": ""
+  },
   "Test notification": {
     "Test notification": "Testnotificatie"
   },
@@ -1087,6 +1111,9 @@
   },
   "Week": {
     "Week": "Week"
+  },
+  "Week event title lines": {
+    "Week event title lines": ""
   },
   "Week view": {
     "Week view": "Weekweergave"

--- a/quickshell/translations/poexports/pl.json
+++ b/quickshell/translations/poexports/pl.json
@@ -44,8 +44,11 @@
   "1 hour before": {
     "1 hour before": "1 godzina przed"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
-    "1 minute": ""
+    "1 minute": "1 minuta"
   },
   "1 week before": {
     "1 week before": "1 tydzień przed"
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "2 godziny przed"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24-godzinny"
   },
   "24h": {
     "24h": "24 godz."
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30 minut"
@@ -132,7 +141,7 @@
     "Add": "Dodaj"
   },
   "Add a CalDAV, local, Google, or Microsoft account with a task list to create tasks.": {
-    "Add a CalDAV, local, Google, or Microsoft account with a task list to create tasks.": ""
+    "Add a CalDAV, local, Google, or Microsoft account with a task list to create tasks.": "Dodaj konto CalDAV, lokalne, Google lub Microsoft z listą zadań, aby tworzyć zadania."
   },
   "Add a calendar": {
     "Add a calendar": "Dodaj kalendarz"
@@ -144,7 +153,7 @@
     "Add description": "Dodaj opis"
   },
   "Add task": {
-    "Add task": ""
+    "Add task": "Dodaj zadanie"
   },
   "Add title": {
     "Add title": "Dodaj tytuł"
@@ -168,7 +177,7 @@
     "All day": "Cały dzień"
   },
   "All done": {
-    "All done": ""
+    "All done": "Wszystko zrobione"
   },
   "All-day reminder time": {
     "All-day reminder time": "Czas przypomnienia całodniowego"
@@ -246,7 +255,7 @@
     "Calendars": "Kalendarze"
   },
   "Calendars couldn't be loaded; tasks are still syncing.": {
-    "Calendars couldn't be loaded; tasks are still syncing.": ""
+    "Calendars couldn't be loaded; tasks are still syncing.": "Nie udało się załadować kalendarzy; trwa synchronizacja zadań."
   },
   "Cancel": {
     "Cancel": "Anuluj"
@@ -285,7 +294,7 @@
     "Coming soon": "Wkrótce"
   },
   "Completed": {
-    "Completed": ""
+    "Completed": "Ukończono"
   },
   "Confirm": {
     "Confirm": "Potwierdź"
@@ -315,7 +324,7 @@
     "Continue": "Dalej"
   },
   "Copied to clipboard": {
-    "Copied to clipboard": ""
+    "Copied to clipboard": "Skopiowano do schowka"
   },
   "Copy link": {
     "Copy link": "Kopiuj link"
@@ -330,7 +339,7 @@
     "Could not read that file.": "Nie udało się odczytać tego pliku."
   },
   "Couldn't update task": {
-    "Couldn't update task": ""
+    "Couldn't update task": "Nie udało się zaktualizować zadania"
   },
   "Create": {
     "Create": "Utwórz"
@@ -354,7 +363,7 @@
     "Daemon offline": "Usługa w tle offline"
   },
   "Daily": {
-    "Daily": ""
+    "Daily": "Codziennie"
   },
   "Dank Calendar is a calendar for the modern Linux desktop with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design, plus a hackable CLI and socket API for integrations.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": {
     "Dank Calendar is a calendar for the modern Linux desktop with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design, plus a hackable CLI and socket API for integrations.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": "Dank Calendar to kalendarz dla nowoczesnych pulpitów linuksowych <a href=\"https://m3.material.io/\" o wyglądzie inspirowanym Material 3</a>, wyposażony w podatne na modyfikacje CLI oraz socket API do tworzenia integracji.<br /><br />Został zbudowany przy użyciu <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a> – frameworka Qt6 do tworzenia powłok graficznych – oraz <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, statycznie typowanego i kompilowanego języka programowania."
@@ -423,7 +432,7 @@
     "Documents": "Dokumenty"
   },
   "Does not repeat": {
-    "Does not repeat": ""
+    "Does not repeat": "NIe powtarza się"
   },
   "Done": {
     "Done": "Gotowe"
@@ -435,13 +444,13 @@
     "Drag to pan · click to fit": "Przeciągnij, aby przesunąć · kliknij, aby dopasować"
   },
   "Due date": {
-    "Due date": ""
+    "Due date": "Termin wykonania"
   },
   "Edit event": {
     "Edit event": "Edytuj wydarzenie"
   },
   "Edit task": {
-    "Edit task": ""
+    "Edit task": "Edytuj zadanie"
   },
   "Enable reminders": {
     "Enable reminders": "Włącz przypomnienia"
@@ -471,7 +480,7 @@
     "Event details": "Szczegóły wydarzenia"
   },
   "Every": {
-    "Every": ""
+    "Every": "Każdego"
   },
   "Evolution": {
     "Evolution": "Evolution"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "Idź do dnia"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google wymaga utworzenia własnego klienta OAuth, aby móc odczytywać dane kalendarza w Twoim imieniu. Jest to jednorazowa konfiguracja, która zajmuje około trzech minut. "
   },
@@ -519,7 +531,7 @@
     "Hide": "Ukryj"
   },
   "High": {
-    "High": ""
+    "High": "Wysoki"
   },
   "Home": {
     "Home": "Strona główna"
@@ -528,7 +540,7 @@
     "How long the snooze button postpones a reminder.": "Czas odroczenia przypomnienia przez przycisk drzemki"
   },
   "How often accounts are polled for changes.": {
-    "How often accounts are polled for changes.": ""
+    "How often accounts are polled for changes.": "Częstotliwość sprawdzania zmian na kontach."
   },
   "Import client_secret.json": {
     "Import client_secret.json": "Importuj plik client_secret.json"
@@ -564,7 +576,7 @@
     "Light": "Jasny"
   },
   "List": {
-    "List": ""
+    "List": "Lista"
   },
   "Load colors from your own theme file.": {
     "Load colors from your own theme file.": "Wczytaj kolory z własnego pliku motywu."
@@ -585,19 +597,25 @@
     "Location": "Lokalizacja"
   },
   "Low": {
-    "Low": ""
+    "Low": "Niski"
   },
   "Marked as not done": {
-    "Marked as not done": ""
+    "Marked as not done": "Oznaczono jako nieukończone"
+  },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
   },
   "Maybe": {
     "Maybe": "Może"
   },
   "Medium": {
-    "Medium": ""
+    "Medium": "Średni"
   },
   "Microsoft To Do access wasn't granted. Reconnect this account to sync tasks.": {
-    "Microsoft To Do access wasn't granted. Reconnect this account to sync tasks.": ""
+    "Microsoft To Do access wasn't granted. Reconnect this account to sync tasks.": "Nie udzielono dostępu do Microsoft To Do. Połącz ponownie to konto, aby zsynchronizować zadania."
   },
   "Microsoft often returns server_error for the first few minutes after an app registration is created or changed. Wait a minute or two and try again.": {
     "Microsoft often returns server_error for the first few minutes after an app registration is created or changed. Wait a minute or two and try again.": "Microsoft często zwraca błąd „server_error” przez kilka pierwszych minut po utworzeniu lub zmianie rejestracji aplikacji. Odczekaj minutę lub dwie i spróbuj ponownie."
@@ -614,11 +632,14 @@
   "Month": {
     "Month": "Miesiąc"
   },
+  "Month event title lines": {
+    "Month event title lines": ""
+  },
   "Month view": {
     "Month view": "Widok miesiąca"
   },
   "Monthly": {
-    "Monthly": ""
+    "Monthly": "Co miesiąc"
   },
   "Move to Trash": {
     "Move to Trash": "Przenieś do kosza"
@@ -648,7 +669,7 @@
     "New event": "Nowe wydarzenie"
   },
   "New task": {
-    "New task": ""
+    "New task": "Nowe zadanie"
   },
   "Next day": {
     "Next day": "Następny dzień"
@@ -675,16 +696,16 @@
     "No calendars yet. Add one to start creating events.": "Brak kalendarzy. Dodaj jeden, aby zacząć tworzyć wydarzenia."
   },
   "No due date": {
-    "No due date": ""
+    "No due date": "Brak terminu"
   },
   "No matching events": {
     "No matching events": "Brak pasujących wydarzeń"
   },
   "No task list available": {
-    "No task list available": ""
+    "No task list available": "Brak dostępnych list zadań"
   },
   "No tasks yet": {
-    "No tasks yet": ""
+    "No tasks yet": "Brak zadań"
   },
   "No theme file selected": {
     "No theme file selected": "Nie wybrano pliku motywu."
@@ -702,7 +723,7 @@
     "Not signed in — click to reconnect or re-add this account": "Nie jesteś zalogowany — kliknij, aby ponownie się połączyć lub dodać konto."
   },
   "Notes": {
-    "Notes": ""
+    "Notes": "Notatki"
   },
   "Nothing scheduled in the next %1 days": {
     "Nothing scheduled in the next %1 days": "Brak zaplanowanych wydarzeń na najbliższe %1 dni."
@@ -738,7 +759,7 @@
     "Outlook, Office 365 and Exchange Online calendars.": "Kalendarze Outlook, Office 365 i Exchange Online."
   },
   "Overdue": {
-    "Overdue": ""
+    "Overdue": "Zaległe"
   },
   "Override": {
     "Override": "Nadpisz"
@@ -795,7 +816,7 @@
     "Previous week": "Poprzedni weekend"
   },
   "Priority": {
-    "Priority": ""
+    "Priority": "Priorytet"
   },
   "Quick Access": {
     "Quick Access": "Szybki dostęp"
@@ -807,7 +828,7 @@
     "Reconnect": "Połącz ponownie"
   },
   "Recurring tasks are managed in Google Tasks.": {
-    "Recurring tasks are managed in Google Tasks.": ""
+    "Recurring tasks are managed in Google Tasks.": "Zadaniami cyklicznymi zarządza się w Google Tasks."
   },
   "Reminders and desktop alerts.": {
     "Reminders and desktop alerts.": "Przypomnienia i powiadomienia na pulpicie."
@@ -843,16 +864,16 @@
     "Rename…": "Zmień nazwę..."
   },
   "Repeat": {
-    "Repeat": ""
+    "Repeat": "Powtarzaj"
   },
   "Repeats": {
-    "Repeats": ""
+    "Repeats": "Powtarza"
   },
   "Repeats every %1": {
-    "Repeats every %1": ""
+    "Repeats every %1": "Powtarzaj co %1"
   },
   "Repeats every %1 %2": {
-    "Repeats every %1 %2": ""
+    "Repeats every %1 %2": "Powtarzaj co %1 %2"
   },
   "Reset to global": {
     "Reset to global": "Przywróć ustawienia globalne"
@@ -903,10 +924,10 @@
     "Show all-day reminders": "Show all-day reminders"
   },
   "Show task lists and the Tasks view when an account provides them.": {
-    "Show task lists and the Tasks view when an account provides them.": ""
+    "Show task lists and the Tasks view when an account provides them.": "Wyświetlaj listy zadań oraz widok zadań, gdy konto je udostępnia."
   },
   "Show tasks": {
-    "Show tasks": ""
+    "Show tasks": "Pokaż zadania"
   },
   "Show week numbers": {
     "Show week numbers": "Pokaż numery tygodni"
@@ -966,7 +987,7 @@
     "Subscribing…": "Subskrybowanie…"
   },
   "Sync interval": {
-    "Sync interval": ""
+    "Sync interval": "Częstotliwość synchronizacji"
   },
   "Sync now": {
     "Sync now": "Synchronizuj teraz"
@@ -984,16 +1005,19 @@
     "Tab/Shift+Tab: Nav • ←→↑↓: Grid Nav • Enter/Space: Select": "Tab/Shift+Tab: Nawigacja • ←→↑↓: Nawigacja po siatce • Enter/Spacja: Wybierz"
   },
   "Task": {
-    "Task": ""
+    "Task": "Zadanie"
   },
   "Task completed": {
-    "Task completed": ""
+    "Task completed": "Zadanie ukończone"
   },
   "Task lists couldn't be loaded; calendars are still syncing.": {
-    "Task lists couldn't be loaded; calendars are still syncing.": ""
+    "Task lists couldn't be loaded; calendars are still syncing.": "Nie można wczytać list zadań; kalendarze są w trakcie synchronizacji."
   },
   "Tasks": {
-    "Tasks": ""
+    "Tasks": "Zadania"
+  },
+  "Tasks view": {
+    "Tasks view": ""
   },
   "Test notification": {
     "Test notification": "Powiadomienie testowe"
@@ -1035,13 +1059,13 @@
     "Type at least 2 characters to search events.": "Wpisz co najmniej 2 znaki, aby wyszukać wydarzenia. "
   },
   "Undo": {
-    "Undo": ""
+    "Undo": "Cofnij"
   },
   "University timetable": {
     "University timetable": "Plan zajęć na uczelni"
   },
   "Upcoming": {
-    "Upcoming": ""
+    "Upcoming": "Nadchodzące"
   },
   "Use a bundled color palette.": {
     "Use a bundled color palette.": "Użyj wbudowanej palety kolorów."
@@ -1088,11 +1112,14 @@
   "Week": {
     "Week": "Tydzień"
   },
+  "Week event title lines": {
+    "Week event title lines": ""
+  },
   "Week view": {
     "Week view": "Widok tygodnia"
   },
   "Weekly": {
-    "Weekly": ""
+    "Weekly": "Co tydzień"
   },
   "What the window's close button does.": {
     "What the window's close button does.": "Określa działanie przycisku zamykania okna."
@@ -1101,7 +1128,7 @@
     "When all-day event reminders fire.": "Czas przypomnień o wydarzeniach całodniowych."
   },
   "Yearly": {
-    "Yearly": ""
+    "Yearly": "Co rok"
   },
   "Yesterday": {
     "Yesterday": "Wczoraj"
@@ -1122,10 +1149,10 @@
     "dark": "ciemny"
   },
   "day": {
-    "day": ""
+    "day": "dzień"
   },
   "days": {
-    "days": ""
+    "days": "dni"
   },
   "iCal subscription": {
     "iCal subscription": "Subskrypcja kalendarza iCal"
@@ -1134,10 +1161,10 @@
     "light": "jasny"
   },
   "month": {
-    "month": ""
+    "month": "miesiąc"
   },
   "months": {
-    "months": ""
+    "months": "miesiące"
   },
   "only if the feed requires sign-in": {
     "only if the feed requires sign-in": "tylko jeśli kanał wymaga logowania"
@@ -1155,16 +1182,16 @@
     "username": "nazwa użytkownika"
   },
   "week": {
-    "week": ""
+    "week": "tydzień"
   },
   "weeks": {
-    "weeks": ""
+    "weeks": "tygodnie"
   },
   "year": {
-    "year": ""
+    "year": "rok"
   },
   "years": {
-    "years": ""
+    "years": "lata"
   },
   "· %1 invited · %2 accepted": {
     "· %1 invited · %2 accepted": "· Zaproszono: %1 · Przyjęto: %2"

--- a/quickshell/translations/poexports/ru.json
+++ b/quickshell/translations/poexports/ru.json
@@ -44,6 +44,9 @@
   "1 hour before": {
     "1 hour before": "За 1 час"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
     "1 minute": ""
   },
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "За 2 часа"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24-часовой"
   },
   "24h": {
     "24h": "24 ч."
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30 минут"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "Перейти к сегодняшнему дню"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google требует создания собственного клиента OAuth для чтения данных календаря от вашего имени. Это одноразовая настройка, занимающая около трёх минут."
   },
@@ -590,6 +602,12 @@
   "Marked as not done": {
     "Marked as not done": ""
   },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
+  },
   "Maybe": {
     "Maybe": ""
   },
@@ -613,6 +631,9 @@
   },
   "Month": {
     "Month": "Месяц"
+  },
+  "Month event title lines": {
+    "Month event title lines": ""
   },
   "Month view": {
     "Month view": "Режим месяца"
@@ -995,6 +1016,9 @@
   "Tasks": {
     "Tasks": ""
   },
+  "Tasks view": {
+    "Tasks view": ""
+  },
   "Test notification": {
     "Test notification": "Тестовое уведомление"
   },
@@ -1087,6 +1111,9 @@
   },
   "Week": {
     "Week": "Неделя"
+  },
+  "Week event title lines": {
+    "Week event title lines": ""
   },
   "Week view": {
     "Week view": "Режим недели"

--- a/quickshell/translations/poexports/uk.json
+++ b/quickshell/translations/poexports/uk.json
@@ -44,6 +44,9 @@
   "1 hour before": {
     "1 hour before": "за 1 годину"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
     "1 minute": ""
   },
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "за 2 години"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24-годинний"
   },
   "24h": {
     "24h": "24 год."
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30 хвилин"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "Перейти до сьогоднішнього дня"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google вимагає від вас створити власний клієнт OAuth для читання даних календаря від вашого імені. Це одноразове налаштування, яке займає близько трьох хвилин."
   },
@@ -590,6 +602,12 @@
   "Marked as not done": {
     "Marked as not done": ""
   },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
+  },
   "Maybe": {
     "Maybe": ""
   },
@@ -613,6 +631,9 @@
   },
   "Month": {
     "Month": "Місяць"
+  },
+  "Month event title lines": {
+    "Month event title lines": ""
   },
   "Month view": {
     "Month view": "Режим місяця"
@@ -995,6 +1016,9 @@
   "Tasks": {
     "Tasks": ""
   },
+  "Tasks view": {
+    "Tasks view": ""
+  },
   "Test notification": {
     "Test notification": "Тестове сповіщення"
   },
@@ -1087,6 +1111,9 @@
   },
   "Week": {
     "Week": "Тиждень"
+  },
+  "Week event title lines": {
+    "Week event title lines": ""
   },
   "Week view": {
     "Week view": "Режим тижня"

--- a/quickshell/translations/poexports/vi.json
+++ b/quickshell/translations/poexports/vi.json
@@ -44,6 +44,9 @@
   "1 hour before": {
     "1 hour before": "1 giờ trước"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
     "1 minute": ""
   },
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "2 giờ trước"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24 giờ"
   },
   "24h": {
     "24h": "24h"
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30 phút"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "Đến hôm nay"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google yêu cầu bạn tạo OAuth client riêng để đọc dữ liệu lịch. Đây là thiết lập một lần, mất khoảng ba phút."
   },
@@ -590,6 +602,12 @@
   "Marked as not done": {
     "Marked as not done": ""
   },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
+  },
   "Maybe": {
     "Maybe": ""
   },
@@ -613,6 +631,9 @@
   },
   "Month": {
     "Month": "Tháng"
+  },
+  "Month event title lines": {
+    "Month event title lines": ""
   },
   "Month view": {
     "Month view": "Chế độ tháng"
@@ -995,6 +1016,9 @@
   "Tasks": {
     "Tasks": ""
   },
+  "Tasks view": {
+    "Tasks view": ""
+  },
   "Test notification": {
     "Test notification": "Thông báo thử nghiệm"
   },
@@ -1087,6 +1111,9 @@
   },
   "Week": {
     "Week": "Tuần"
+  },
+  "Week event title lines": {
+    "Week event title lines": ""
   },
   "Week view": {
     "Week view": "Chế độ tuần"

--- a/quickshell/translations/poexports/zh_CN.json
+++ b/quickshell/translations/poexports/zh_CN.json
@@ -44,8 +44,11 @@
   "1 hour before": {
     "1 hour before": "1小时前"
   },
+  "1 line": {
+    "1 line": ""
+  },
   "1 minute": {
-    "1 minute": ""
+    "1 minute": "1分钟"
   },
   "1 week before": {
     "1 week before": "1周前"
@@ -80,11 +83,17 @@
   "2 hours before": {
     "2 hours before": "2小时前"
   },
+  "2 lines": {
+    "2 lines": ""
+  },
   "24-hour": {
     "24-hour": "24-小时制"
   },
   "24h": {
     "24h": "24小时"
+  },
+  "3 lines": {
+    "3 lines": ""
   },
   "30 minutes": {
     "30 minutes": "30分钟"
@@ -132,7 +141,7 @@
     "Add": "添加"
   },
   "Add a CalDAV, local, Google, or Microsoft account with a task list to create tasks.": {
-    "Add a CalDAV, local, Google, or Microsoft account with a task list to create tasks.": ""
+    "Add a CalDAV, local, Google, or Microsoft account with a task list to create tasks.": "添加 CalDAV，本地，谷歌或微软账户的任务列表以创建任务。"
   },
   "Add a calendar": {
     "Add a calendar": "添加日历"
@@ -144,7 +153,7 @@
     "Add description": "添加描述"
   },
   "Add task": {
-    "Add task": ""
+    "Add task": "添加任务"
   },
   "Add title": {
     "Add title": "添加标题"
@@ -168,7 +177,7 @@
     "All day": "全天"
   },
   "All done": {
-    "All done": ""
+    "All done": "全部完成"
   },
   "All-day reminder time": {
     "All-day reminder time": "全天日程提醒时间"
@@ -246,7 +255,7 @@
     "Calendars": "日历"
   },
   "Calendars couldn't be loaded; tasks are still syncing.": {
-    "Calendars couldn't be loaded; tasks are still syncing.": ""
+    "Calendars couldn't be loaded; tasks are still syncing.": "日历无法加载；仍在同步任务。"
   },
   "Cancel": {
     "Cancel": "取消"
@@ -285,7 +294,7 @@
     "Coming soon": "即将推出"
   },
   "Completed": {
-    "Completed": ""
+    "Completed": "已完成"
   },
   "Confirm": {
     "Confirm": "确认"
@@ -315,7 +324,7 @@
     "Continue": "继续"
   },
   "Copied to clipboard": {
-    "Copied to clipboard": ""
+    "Copied to clipboard": "拷贝到粘贴板"
   },
   "Copy link": {
     "Copy link": "复制链接"
@@ -330,7 +339,7 @@
     "Could not read that file.": "无法读取文件。"
   },
   "Couldn't update task": {
-    "Couldn't update task": ""
+    "Couldn't update task": "无法更新任务"
   },
   "Create": {
     "Create": "创建"
@@ -354,7 +363,7 @@
     "Daemon offline": "守护进程已离线"
   },
   "Daily": {
-    "Daily": ""
+    "Daily": "每日"
   },
   "Dank Calendar is a calendar for the modern Linux desktop with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design, plus a hackable CLI and socket API for integrations.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": {
     "Dank Calendar is a calendar for the modern Linux desktop with a <a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">material 3 inspired</a> design, plus a hackable CLI and socket API for integrations.<br /><br/>It is built with <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>, a QT6 framework for building desktop shells, and <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a>, a statically typed, compiled programming language.": "Dank Calendar 是一款专为现代 Linux 桌面打造的日历软件，采用了<a href=\"https://m3.material.io/\" style=\"text-decoration:none; color:%1;\">源自 Material 3 的设计灵感</a>，同时还提供强大的 CLI（命令行界面）和 Socket API 以便进行系统集成。<br /><br/>它基于 <a href=\"https://quickshell.org\" style=\"text-decoration:none; color:%1;\">Quickshell</a>（一个用于构建桌面 Shell 的 Qt6 框架）以及 <a href=\"https://go.dev\" style=\"text-decoration:none; color:%1;\">Go</a> 语言（一种静态类型、编译型的编程语言）开发而成。"
@@ -512,6 +521,9 @@
   "Go to today": {
     "Go to today": "转到今天"
   },
+  "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": {
+    "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.": ""
+  },
   "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": {
     "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.": "Google 要求您创建自己的 OAuth 客户端，以便代表您读取日历数据。这是一次性设置，大约需要三分钟。"
   },
@@ -590,6 +602,12 @@
   "Marked as not done": {
     "Marked as not done": ""
   },
+  "Maximum title lines per event in month view.": {
+    "Maximum title lines per event in month view.": ""
+  },
+  "Maximum title lines per event in week view.": {
+    "Maximum title lines per event in week view.": ""
+  },
   "Maybe": {
     "Maybe": "或许"
   },
@@ -613,6 +631,9 @@
   },
   "Month": {
     "Month": "月"
+  },
+  "Month event title lines": {
+    "Month event title lines": ""
   },
   "Month view": {
     "Month view": "月视图"
@@ -801,7 +822,7 @@
     "Quick Access": "快速访问"
   },
   "Quit": {
-    "Quit": "离开"
+    "Quit": "退出"
   },
   "Reconnect": {
     "Reconnect": "重新连接"
@@ -995,6 +1016,9 @@
   "Tasks": {
     "Tasks": ""
   },
+  "Tasks view": {
+    "Tasks view": ""
+  },
   "Test notification": {
     "Test notification": "测试通知"
   },
@@ -1087,6 +1111,9 @@
   },
   "Week": {
     "Week": "周"
+  },
+  "Week event title lines": {
+    "Week event title lines": ""
   },
   "Week view": {
     "Week view": "周视图"

--- a/quickshell/translations/template.json
+++ b/quickshell/translations/template.json
@@ -1197,6 +1197,13 @@
     "comment": ""
   },
   {
+    "term": "Google Tasks is unavailable. <a href=\"https://console.cloud.google.com/apis/library/tasks.googleapis.com\" style=\"text-decoration:none; color:%1;\">Enable its API</a> or reconnect this account, then refresh, to sync tasks.",
+    "translation": "",
+    "context": "account notice when google tasks is disabled or its permission is missing",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Google requires you to create your own OAuth client to read calendar data on your behalf. This is a one-time setup that takes about three minutes.",
     "translation": "",
     "context": "google oauth setup intro text",


### PR DESCRIPTION
## Summary

- invalidate existing calendar sync cursors once so events stored before `meeting_url` was added are fetched again
- keep Google Calendar syncing when an older OAuth token lacks the optional Google Tasks scope
- show a clearer Tasks notice and cover both migration and scope handling with tests

## Why

This is a follow-up to #18. Existing events were not backfilled after the `meeting_url` column was introduced because incremental sync cursors prevented unchanged events from being fetched again.

For Google accounts authorized before Tasks support, the full refresh was also blocked by `403 ACCESS_TOKEN_SCOPE_INSUFFICIENT` from the Tasks API. Tasks are optional, so that error now degrades Tasks while Calendar continues syncing.

## Validation

- `make test`
- `make i18n-test`
- manually verified that a previously synced Google event recovered its structured `conferenceData` URL and displayed **Join video call**
