### PR TITLE
Fix reminders/invitations busy-loop on large sync snapshots

### DIFF
--- a/core/internal/invitations/engine.go
+++ b/core/internal/invitations/engine.go
@@ -34,6 +34,11 @@ const (
 	// defaultMaxWake caps how long the engine parks between scans; a backstop
 	// against a missed wake signal, not the normal path.
 	defaultMaxWake = time.Hour
+	// coalesce bounds how soon a wake may force a rescan. A sync pass can
+	// rewrite thousands of Event rows individually, each firing Wake(); without
+	// this, every single row would trigger its own full recurring-event
+	// re-expansion. Wakes arriving faster than this just push the scan out.
+	coalesce = 2 * time.Second
 )
 
 // Sender is the subset of the notify client the engine needs.
@@ -157,6 +162,8 @@ func (e *Engine) loop(ctx context.Context) {
 		case <-e.stop:
 			return
 		case <-e.wake:
+			resetTimer(timer, coalesce)
+			continue
 		case <-timer.C:
 		}
 

--- a/core/internal/providers/google/provider.go
+++ b/core/internal/providers/google/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/AvengeMedia/dankcalendar/core/internal/log"
 	"github.com/AvengeMedia/dankcalendar/core/internal/oauth"
 	"github.com/AvengeMedia/dankcalendar/core/internal/providers/oauthbase"
+	"github.com/AvengeMedia/dankcalendar/core/internal/tzcache"
 )
 
 const maxPageSize = 2500
@@ -510,7 +511,7 @@ func toGoogleEvent(ev *cal.Event) *calendar.Event {
 func toGoogleDateTime(t time.Time, tz string) *calendar.EventDateTime {
 	dt := &calendar.EventDateTime{}
 	if tz != "" {
-		if loc, err := time.LoadLocation(tz); err == nil {
+		if loc, err := tzcache.Load(tz); err == nil {
 			t = t.In(loc)
 		}
 		dt.TimeZone = tz

--- a/core/internal/providers/icalconv/timezone.go
+++ b/core/internal/providers/icalconv/timezone.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AvengeMedia/dankcalendar/core/internal/tzcache"
 	ical "github.com/emersion/go-ical"
 	"github.com/teambition/rrule-go"
 )
@@ -74,11 +75,11 @@ func loadZone(name string) (*time.Location, string) {
 	if name == "" {
 		return nil, ""
 	}
-	if loc, err := time.LoadLocation(name); err == nil {
+	if loc, err := tzcache.Load(name); err == nil {
 		return loc, name
 	}
 	if iana := windowsZones[name]; iana != "" {
-		if loc, err := time.LoadLocation(iana); err == nil {
+		if loc, err := tzcache.Load(iana); err == nil {
 			return loc, iana
 		}
 	}
@@ -122,11 +123,11 @@ func (r *TZResolver) location(tzid string, when time.Time) (*time.Location, stri
 	if tzid == "" {
 		return time.UTC, ""
 	}
-	if loc, err := time.LoadLocation(tzid); err == nil {
+	if loc, err := tzcache.Load(tzid); err == nil {
 		return loc, tzid
 	}
 	if iana := windowsZones[tzid]; iana != "" {
-		if loc, err := time.LoadLocation(iana); err == nil {
+		if loc, err := tzcache.Load(iana); err == nil {
 			return loc, iana
 		}
 	}

--- a/core/internal/recurrence/expand.go
+++ b/core/internal/recurrence/expand.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AvengeMedia/dankcalendar/core/internal/tzcache"
 	"github.com/teambition/rrule-go"
 )
 
@@ -66,7 +67,7 @@ func (s Series) location() *time.Location {
 	case s.AllDay:
 		return time.UTC
 	case s.TimeZone != "":
-		if loc, err := time.LoadLocation(s.TimeZone); err == nil {
+		if loc, err := tzcache.Load(s.TimeZone); err == nil {
 			return loc
 		}
 	}

--- a/core/internal/reminders/engine.go
+++ b/core/internal/reminders/engine.go
@@ -39,6 +39,14 @@ const (
 	allDayLate = 24 * time.Hour
 	stateFloor = 35 * 24 * time.Hour
 	pruneAfter = 60 * 24 * time.Hour
+	// minWake floors how soon the loop may re-evaluate so an overdue or
+	// unresolved trigger can never busy-loop the engine.
+	minWake = time.Second
+	// coalesce bounds how soon a wake may force a rescan. A sync pass can
+	// rewrite thousands of Event rows individually, each firing Wake(); without
+	// this, every single row would trigger its own full recurring-event
+	// re-expansion. Wakes arriving faster than this just push the scan out.
+	coalesce = 2 * time.Second
 	// defaultMaxWake caps how long the engine parks; a backstop against a
 	// missed wake signal or an undetected clock change, not the normal path.
 	defaultMaxWake = time.Hour
@@ -191,6 +199,8 @@ func (e *Engine) loop(ctx context.Context) {
 		case <-e.stop:
 			return
 		case <-e.wake:
+			resetTimer(timer, coalesce)
+			continue
 		case <-timer.C:
 		}
 
@@ -215,8 +225,8 @@ func (e *Engine) untilNext(ctx context.Context) time.Duration {
 		return e.maxWake
 	}
 	switch d := up[0].Trigger.Sub(e.now()); {
-	case d < 0:
-		return 0
+	case d < minWake:
+		return minWake
 	case d > e.maxWake:
 		return e.maxWake
 	default:

--- a/core/internal/tzcache/tzcache.go
+++ b/core/internal/tzcache/tzcache.go
@@ -1,0 +1,25 @@
+// Package tzcache memoizes time.LoadLocation. The stdlib re-reads tzdata from
+// disk on every call; callers that resolve the same handful of zones many
+// times per pass (recurrence expansion, iCal timezone resolution) would
+// otherwise turn that into a filesystem hot loop.
+package tzcache
+
+import (
+	"sync"
+	"time"
+)
+
+var cache sync.Map // string -> *time.Location
+
+// Load is a drop-in, cached replacement for time.LoadLocation.
+func Load(name string) (*time.Location, error) {
+	if v, ok := cache.Load(name); ok {
+		return v.(*time.Location), nil
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return nil, err
+	}
+	cache.Store(name, loc)
+	return loc, nil
+}


### PR DESCRIPTION
Fixes the CPU busy-loop reported in #33.

## Root cause

A full-snapshot sync (e.g. an `ical` webcal feed) upserts every event individually via `sync/engine.go`'s `applyChanges`. Both `reminders/engine.go` and `invitations/engine.go` register `WatchMutations` hooks on `Event`/`Calendar`/`Account` that call `Wake()` after every successful mutation. `Wake()` is serviced immediately by the engines' `select`, bypassing any timer floor — so a sync of a few thousand events fires that many back-to-back re-`Tick()`s, and each `Tick()` re-expands every recurring master event via `time.LoadLocation`, which is uncached in the stdlib and re-reads tzdata from disk every call. On a calendar with a few hundred recurring events this pins a CPU core reopening `/usr/share/zoneinfo` files continuously.

There's also a second, independent uncached `time.LoadLocation` call site in `icalconv/timezone.go` used while parsing the feed itself, which a wake/timer fix alone wouldn't touch.

## Fix

- Coalesce wakes in both engines' `loop()` behind a short (`2s`) settle window, so a burst of Event/Calendar/Account mutations collapses into a single rescan instead of one per row.
- Floor `reminders/engine.go`'s timer-driven re-arm at `1s` too, so an overdue/unresolved trigger can't independently busy-loop the timer path.
- Add `internal/tzcache` to memoize `time.LoadLocation`, wired into `recurrence/expand.go`, `icalconv/timezone.go`, and `providers/google/provider.go` (all three call sites on this general class of hot path).

## Verification

A/B tested against a full copy of a real production DB (6473 events, 606 recurring masters), isolated `XDG_*` dirs, `dcal daemon` (no UI), sampling `%CPU` via `ps` every 5s for 60s:

| t | unpatched | patched |
|---|---|---|
| 5s | 41% | 39% |
| 20s | 55% | 23% |
| 35s | 89% | 18% |
| 50s | 103% | 12% |
| 55s | **106% (still climbing)** | **11% (still falling)** |

`strace -f -e trace=openat` over 20s: zoneinfo opens dropped from 24,239 to 426 (>98%).

`go test ./...` passes unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] A/B CPU comparison against real (large) production data, unpatched vs patched binary
- [x] `strace` syscall-count comparison confirming the zoneinfo open storm is gone

## Note

I deliberately left out skipping the no-op `UpdateOne().Save()` in `repo/events_mutations.go` when a synced event is actually unchanged — the `ical` provider doesn't set per-event etags, so that would need a real field-by-field diff against the stored row, which felt too risky to get subtly wrong here. Happy to follow up with that as a separate PR if it's wanted; it would reduce sync-time DB churn further but isn't required to eliminate this busy loop.