### PR TITLE
feat: add configurable core hours with out-of-range warnings

### DIFF
--- a/quickshell/Modals/SettingsContent.qml
+++ b/quickshell/Modals/SettingsContent.qml
@@ -99,6 +99,22 @@ Item {
         }
     ]
 
+    function coreHourLabel(h) {
+        if (h === 24)
+            return "24:00";
+        if (SettingsData.use24HourTime)
+            return (h < 10 ? "0" + h : h) + ":00";
+        const displayH = h % 12 === 0 ? 12 : h % 12;
+        return h < 12 ? I18n.tr("%1 AM", "core hours dropdown hour label, morning").arg(displayH) : I18n.tr("%1 PM", "core hours dropdown hour label, afternoon").arg(displayH);
+    }
+
+    readonly property var coreHourOptions: Array.from({
+        length: 25
+    }, (_, h) => ({
+                label: root.coreHourLabel(h),
+                value: h
+            }))
+
     readonly property var eventTitleLineOptions: [
         {
             label: I18n.tr("1 line", "event title line count dropdown option"),
@@ -432,6 +448,49 @@ Item {
                                     break;
                                 }
                             }
+                        }
+                    }
+
+                    SettingsRow {
+                        label: I18n.tr("Enable core hours", "core hours toggle label")
+                        description: I18n.tr("Limit the day and week views to a set hour range.", "core hours toggle description")
+
+                        DankToggle {
+                            anchors.verticalCenter: parent.verticalCenter
+                            checked: SettingsData.coreHoursEnabled
+                            onToggled: checked => SettingsData.coreHoursEnabled = checked
+                        }
+                    }
+
+                    SettingsRow {
+                        label: I18n.tr("Core hours", "core hours range setting label")
+                        description: I18n.tr("Hour range shown in day and week views.", "core hours range setting description")
+
+                        DankDropdown {
+                            anchors.verticalCenter: parent.verticalCenter
+                            dropdownWidth: 90
+                            enabled: SettingsData.coreHoursEnabled
+                            opacity: enabled ? 1 : 0.5
+                            options: root.optionLabels(root.coreHourOptions.filter(o => o.value < SettingsData.coreHoursEnd))
+                            currentValue: root.labelForValue(root.coreHourOptions, SettingsData.coreHoursStart)
+                            onValueChanged: value => SettingsData.coreHoursStart = root.valueForLabel(root.coreHourOptions, value)
+                        }
+
+                        StyledText {
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: I18n.tr("to", "core hours range separator")
+                            color: Theme.surfaceVariantText
+                            opacity: SettingsData.coreHoursEnabled ? 1 : 0.5
+                        }
+
+                        DankDropdown {
+                            anchors.verticalCenter: parent.verticalCenter
+                            dropdownWidth: 90
+                            enabled: SettingsData.coreHoursEnabled
+                            opacity: enabled ? 1 : 0.5
+                            options: root.optionLabels(root.coreHourOptions.filter(o => o.value > SettingsData.coreHoursStart))
+                            currentValue: root.labelForValue(root.coreHourOptions, SettingsData.coreHoursEnd)
+                            onValueChanged: value => SettingsData.coreHoursEnd = root.valueForLabel(root.coreHourOptions, value)
                         }
                     }
 

--- a/quickshell/Modules/views/DayView.qml
+++ b/quickshell/Modules/views/DayView.qml
@@ -12,7 +12,9 @@ Item {
 
     signal eventClicked(var event)
 
-    readonly property int hourCount: 24
+    readonly property int startHour: SettingsData.effectiveHourStart
+    readonly property int endHour: SettingsData.effectiveHourEnd
+    readonly property int hourCount: endHour - startHour
     readonly property real hourHeight: 56
     readonly property real timeColumnWidth: 72
 
@@ -65,19 +67,98 @@ Item {
             const ev = dayEvents[i];
             if (ev.allDay)
                 continue;
-            const s = Math.max(ev.start.getTime(), dayStart.getTime());
-            const e = Math.min(ev.end.getTime(), dayEnd.getTime());
+            const coreStart = dayStart.getTime() + root.startHour * 3600000;
+            const coreEnd = dayStart.getTime() + root.endHour * 3600000;
+            const s = Math.max(ev.start.getTime(), dayStart.getTime(), coreStart);
+            const e = Math.min(ev.end.getTime(), dayEnd.getTime(), coreEnd);
+            if (e <= s)
+                continue;
             const decorated = Object.assign({}, ev);
-            decorated.startHour = (s - dayStart.getTime()) / 3600000;
+            decorated.startHour = (s - dayStart.getTime()) / 3600000 - root.startHour;
             decorated.durationHours = Math.max((e - s) / 3600000, 0.5);
             out.push(decorated);
         }
         return DankCalService.layoutTimedEvents(out);
     }
 
+    readonly property var hiddenInfo: {
+        eventsVersion;
+        const dayStart = new Date(displayDate.getFullYear(), displayDate.getMonth(), displayDate.getDate());
+        const dayEnd = new Date(dayStart.getTime() + 86400000);
+        const coreStart = dayStart.getTime() + root.startHour * 3600000;
+        const coreEnd = dayStart.getTime() + root.endHour * 3600000;
+        let count = 0;
+        let before = false;
+        let after = false;
+        for (let i = 0; i < dayEvents.length; i++) {
+            const ev = dayEvents[i];
+            if (ev.allDay)
+                continue;
+            const s0 = Math.max(ev.start.getTime(), dayStart.getTime());
+            const e0 = Math.min(ev.end.getTime(), dayEnd.getTime());
+            if (e0 <= s0)
+                continue;
+            if (s0 < coreStart)
+                before = true;
+            if (e0 > coreEnd)
+                after = true;
+            if (s0 < coreStart || e0 > coreEnd)
+                count++;
+        }
+        return {
+            count: count,
+            before: before,
+            after: after
+        };
+    }
+
+    readonly property int hiddenEventCount: hiddenInfo.count
+
+    Rectangle {
+        id: coreHoursWarning
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: visible ? 36 : 0
+        visible: root.hiddenEventCount > 0
+        color: Theme.withAlpha(Theme.warning, 0.18)
+
+        Row {
+            anchors.left: parent.left
+            anchors.leftMargin: Theme.spacingM
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Theme.spacingS
+
+            DankIcon {
+                name: "warning"
+                size: Theme.iconSizeSmall
+                color: Theme.warning
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            StyledText {
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.hiddenEventCount === 1 ? I18n.tr("1 appointment falls outside core hours", "core hours warning banner, singular") : I18n.tr("%1 appointments fall outside core hours", "core hours warning banner, plural").arg(root.hiddenEventCount)
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.warning
+            }
+        }
+
+        DankButton {
+            anchors.right: parent.right
+            anchors.rightMargin: Theme.spacingM
+            anchors.verticalCenter: parent.verticalCenter
+            text: I18n.tr("Disable core hours", "core hours warning banner disable action")
+            backgroundColor: "transparent"
+            textColor: Theme.warning
+            buttonHeight: 28
+            onClicked: SettingsData.coreHoursEnabled = false
+        }
+    }
+
     Column {
         id: allDayStrip
-        anchors.top: parent.top
+        anchors.top: coreHoursWarning.visible ? coreHoursWarning.bottom : parent.top
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.leftMargin: root.timeColumnWidth
@@ -128,9 +209,26 @@ Item {
         }
     }
 
+    Item {
+        id: hiddenBeforeStrip
+        anchors.top: allDayStrip.visible ? allDayStrip.bottom : (coreHoursWarning.visible ? coreHoursWarning.bottom : parent.top)
+        anchors.topMargin: allDayStrip.visible ? Theme.spacingS : (coreHoursWarning.visible ? Theme.spacingS : 0)
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.leftMargin: root.timeColumnWidth
+        height: root.hiddenInfo.before ? 16 : 0
+        visible: root.hiddenInfo.before
+
+        DankIcon {
+            anchors.centerIn: parent
+            name: "keyboard_arrow_up"
+            size: Theme.iconSizeSmall
+            color: Theme.warning
+        }
+    }
+
     DankFlickable {
-        anchors.top: allDayStrip.visible ? allDayStrip.bottom : parent.top
-        anchors.topMargin: allDayStrip.visible ? Theme.spacingS : 0
+        anchors.top: hiddenBeforeStrip.bottom
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
@@ -141,29 +239,23 @@ Item {
             width: parent.width
             height: root.hourHeight * root.hourCount
 
-            Column {
+            Item {
                 anchors.left: parent.left
                 width: root.timeColumnWidth
-                spacing: 0
+                height: parent.height
 
                 Repeater {
-                    model: root.hourCount
+                    model: root.hourCount + 1
 
-                    Item {
+                    StyledText {
                         required property int index
-                        width: parent.width
-                        height: root.hourHeight
-
-                        StyledText {
-                            anchors.right: parent.right
-                            anchors.rightMargin: Theme.spacingS
-                            anchors.top: parent.top
-                            anchors.topMargin: -6
-                            text: root.hourLabel(index)
-                            font.pixelSize: 11
-                            color: Theme.surfaceVariantText
-                            isMonospace: true
-                        }
+                        anchors.right: parent.right
+                        anchors.rightMargin: Theme.spacingS
+                        y: Math.max(0, index * root.hourHeight - 6)
+                        text: root.hourLabel(root.startHour + index)
+                        font.pixelSize: 11
+                        color: Theme.surfaceVariantText
+                        isMonospace: true
                     }
                 }
             }
@@ -174,7 +266,7 @@ Item {
                 height: parent.height
 
                 Repeater {
-                    model: root.hourCount
+                    model: root.hourCount + 1
 
                     Rectangle {
                         required property int index
@@ -185,9 +277,18 @@ Item {
                     }
                 }
 
+                DankIcon {
+                    visible: root.hiddenInfo.after
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    y: root.hourCount * root.hourHeight + 2
+                    name: "keyboard_arrow_down"
+                    size: Theme.iconSizeSmall
+                    color: Theme.warning
+                }
+
                 Item {
-                    visible: root.showsNow
-                    y: root.nowHour * root.hourHeight
+                    visible: root.showsNow && root.nowHour >= root.startHour && root.nowHour < root.endHour
+                    y: (root.nowHour - root.startHour) * root.hourHeight
                     width: parent.width
                     z: 10
 

--- a/quickshell/Modules/views/WeekView.qml
+++ b/quickshell/Modules/views/WeekView.qml
@@ -14,7 +14,9 @@ Item {
 
     signal eventClicked(var event)
 
-    readonly property int hourCount: 24
+    readonly property int startHour: SettingsData.effectiveHourStart
+    readonly property int endHour: SettingsData.effectiveHourEnd
+    readonly property int hourCount: endHour - startHour
     readonly property real hourHeight: 48
     readonly property real timeColumnWidth: 60
     readonly property real allDayChipHeight: Math.max(18, SettingsData.weekEventTitleLines * 13 + 4)
@@ -85,10 +87,14 @@ Item {
             const ev = list[i];
             if (ev.allDay)
                 continue;
-            const s = Math.max(ev.start.getTime(), dayStart.getTime());
-            const e = Math.min(ev.end.getTime(), dayEnd.getTime());
+            const coreStart = dayStart.getTime() + root.startHour * 3600000;
+            const coreEnd = dayStart.getTime() + root.endHour * 3600000;
+            const s = Math.max(ev.start.getTime(), dayStart.getTime(), coreStart);
+            const e = Math.min(ev.end.getTime(), dayEnd.getTime(), coreEnd);
+            if (e <= s)
+                continue;
             const decorated = Object.assign({}, ev);
-            decorated.startHour = (s - dayStart.getTime()) / 3600000;
+            decorated.startHour = (s - dayStart.getTime()) / 3600000 - root.startHour;
             decorated.durationHours = Math.max((e - s) / 3600000, 0.5);
             out.push(decorated);
         }
@@ -107,9 +113,96 @@ Item {
         return Math.min(max, 2);
     }
 
+    function hiddenInfoFor(day) {
+        const dayStart = new Date(day.getFullYear(), day.getMonth(), day.getDate());
+        const dayEnd = new Date(dayStart.getTime() + 86400000);
+        const coreStart = dayStart.getTime() + root.startHour * 3600000;
+        const coreEnd = dayStart.getTime() + root.endHour * 3600000;
+        const list = DankCalService.eventsForDay(day);
+        let count = 0;
+        let before = false;
+        let after = false;
+        for (let i = 0; i < list.length; i++) {
+            const ev = list[i];
+            if (ev.allDay)
+                continue;
+            const s0 = Math.max(ev.start.getTime(), dayStart.getTime());
+            const e0 = Math.min(ev.end.getTime(), dayEnd.getTime());
+            if (e0 <= s0)
+                continue;
+            if (s0 < coreStart)
+                before = true;
+            if (e0 > coreEnd)
+                after = true;
+            if (s0 < coreStart || e0 > coreEnd)
+                count++;
+        }
+        return {
+            count: count,
+            before: before,
+            after: after
+        };
+    }
+
+    readonly property int hiddenEventTotal: {
+        eventsVersion;
+        let total = 0;
+        for (let i = 0; i < 7; i++)
+            total += root.hiddenInfoFor(root.dayAt(i)).count;
+        return total;
+    }
+
+    readonly property bool anyHiddenBefore: {
+        eventsVersion;
+        for (let i = 0; i < 7; i++)
+            if (root.hiddenInfoFor(root.dayAt(i)).before)
+                return true;
+        return false;
+    }
+
     Column {
         anchors.fill: parent
         spacing: 0
+
+        Rectangle {
+            id: coreHoursWarning
+            width: parent.width
+            height: visible ? 36 : 0
+            visible: root.hiddenEventTotal > 0
+            color: Theme.withAlpha(Theme.warning, 0.18)
+
+            Row {
+                anchors.left: parent.left
+                anchors.leftMargin: Theme.spacingM
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Theme.spacingS
+
+                DankIcon {
+                    name: "warning"
+                    size: Theme.iconSizeSmall
+                    color: Theme.warning
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                StyledText {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: root.hiddenEventTotal === 1 ? I18n.tr("1 appointment falls outside core hours", "core hours warning banner, singular") : I18n.tr("%1 appointments fall outside core hours", "core hours warning banner, plural").arg(root.hiddenEventTotal)
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.warning
+                }
+            }
+
+            DankButton {
+                anchors.right: parent.right
+                anchors.rightMargin: Theme.spacingM
+                anchors.verticalCenter: parent.verticalCenter
+                text: I18n.tr("Disable core hours", "core hours warning banner disable action")
+                backgroundColor: "transparent"
+                textColor: Theme.warning
+                buttonHeight: 28
+                onClicked: SettingsData.coreHoursEnabled = false
+            }
+        }
 
         Row {
             width: parent.width
@@ -248,9 +341,43 @@ Item {
             }
         }
 
+        Row {
+            id: hiddenBeforeStrip
+            width: parent.width
+            height: root.anyHiddenBefore ? 16 : 0
+            visible: root.anyHiddenBefore
+
+            Item {
+                width: root.timeColumnWidth
+                height: parent.height
+            }
+
+            Repeater {
+                model: 7
+
+                Item {
+                    required property int index
+                    readonly property date d: root.dayAt(index)
+                    width: (parent.width - root.timeColumnWidth) / 7
+                    height: parent.height
+
+                    DankIcon {
+                        visible: {
+                            root.eventsVersion;
+                            return root.hiddenInfoFor(parent.d).before;
+                        }
+                        anchors.centerIn: parent
+                        name: "keyboard_arrow_up"
+                        size: Theme.iconSizeSmall
+                        color: Theme.warning
+                    }
+                }
+            }
+        }
+
         DankFlickable {
             width: parent.width
-            height: parent.height - 56 - (root.allDayMax > 0 ? root.allDayMax * (root.allDayChipHeight + 4) + 6 : 0)
+            height: parent.height - 56 - coreHoursWarning.height - hiddenBeforeStrip.height - (root.allDayMax > 0 ? root.allDayMax * (root.allDayChipHeight + 4) + 6 : 0)
             contentHeight: root.hourHeight * root.hourCount
             clip: true
 
@@ -258,29 +385,23 @@ Item {
                 width: parent.width
                 height: root.hourHeight * root.hourCount
 
-                Column {
+                Item {
                     anchors.left: parent.left
                     width: root.timeColumnWidth
-                    spacing: 0
+                    height: parent.height
 
                     Repeater {
-                        model: root.hourCount
+                        model: root.hourCount + 1
 
-                        Item {
+                        StyledText {
                             required property int index
-                            width: parent.width
-                            height: root.hourHeight
-
-                            StyledText {
-                                anchors.right: parent.right
-                                anchors.rightMargin: Theme.spacingS
-                                anchors.top: parent.top
-                                anchors.topMargin: -6
-                                text: root.hourLabel(index)
-                                font.pixelSize: 11
-                                color: Theme.surfaceVariantText
-                                isMonospace: true
-                            }
+                            anchors.right: parent.right
+                            anchors.rightMargin: Theme.spacingS
+                            y: Math.max(0, index * root.hourHeight - 6)
+                            text: root.hourLabel(root.startHour + index)
+                            font.pixelSize: 11
+                            color: Theme.surfaceVariantText
+                            isMonospace: true
                         }
                     }
                 }
@@ -310,6 +431,14 @@ Item {
                     }
                 }
 
+                Rectangle {
+                    anchors.right: parent.right
+                    width: parent.width - root.timeColumnWidth
+                    y: root.hourCount * root.hourHeight
+                    height: 1
+                    color: Theme.gridLine
+                }
+
                 Row {
                     anchors.right: parent.right
                     width: parent.width - root.timeColumnWidth
@@ -334,6 +463,18 @@ Item {
                                 width: 1
                                 height: parent.height
                                 color: Theme.gridLine
+                            }
+
+                            DankIcon {
+                                visible: {
+                                    root.eventsVersion;
+                                    return root.hiddenInfoFor(root.dayAt(dayColumn.index)).after;
+                                }
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                y: root.hourCount * root.hourHeight + 2
+                                name: "keyboard_arrow_down"
+                                size: Theme.iconSizeSmall
+                                color: Theme.warning
                             }
 
                             Repeater {
@@ -394,11 +535,11 @@ Item {
                     anchors.right: parent.right
                     width: parent.width - root.timeColumnWidth
                     height: parent.height
-                    visible: root.nowColumn >= 0
+                    visible: root.nowColumn >= 0 && root.nowHour >= root.startHour && root.nowHour < root.endHour
                     z: 10
 
                     Item {
-                        y: root.nowHour * root.hourHeight
+                        y: (root.nowHour - root.startHour) * root.hourHeight
                         width: parent.width
 
                         Rectangle {

--- a/quickshell/Services/SettingsData.qml
+++ b/quickshell/Services/SettingsData.qml
@@ -27,6 +27,9 @@ Singleton {
     property alias firstDayOfWeek: adapter.firstDayOfWeek
     // "auto" | "12h" | "24h"
     property alias timeFormat: adapter.timeFormat
+    property alias coreHoursEnabled: adapter.coreHoursEnabled
+    property alias coreHoursStart: adapter.coreHoursStart
+    property alias coreHoursEnd: adapter.coreHoursEnd
     property alias showWeekNumbers: adapter.showWeekNumbers
     property alias showTasks: adapter.showTasks
     property alias monthEventTitleLines: adapter.monthEventTitleLines
@@ -60,6 +63,9 @@ Singleton {
     }
 
     readonly property int effectiveFirstDayOfWeek: (firstDayOfWeek >= 0 && firstDayOfWeek <= 6) ? firstDayOfWeek : localeFirstDayOfWeek
+    readonly property bool coreHoursValid: coreHoursStart >= 0 && coreHoursEnd <= 24 && coreHoursEnd > coreHoursStart
+    readonly property int effectiveHourStart: (coreHoursEnabled && coreHoursValid) ? coreHoursStart : 0
+    readonly property int effectiveHourEnd: (coreHoursEnabled && coreHoursValid) ? coreHoursEnd : 24
     readonly property bool use24HourTime: {
         switch (timeFormat) {
         case "12h":
@@ -133,6 +139,9 @@ Singleton {
             property int firstDayOfWeek: -1
             property string timeFormat: "auto"
             property bool use24HourClock: true
+            property bool coreHoursEnabled: false
+            property int coreHoursStart: 9
+            property int coreHoursEnd: 17
             property bool showWeekNumbers: false
             property bool showTasks: true
             property int monthEventTitleLines: 1

--- a/quickshell/Widgets/DankToggle.qml
+++ b/quickshell/Widgets/DankToggle.qml
@@ -48,9 +48,6 @@ Item {
         anchors.fill: parent
         cursorShape: root.toggleEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
         enabled: root.toggleEnabled
-        onClicked: {
-            root.checked = !root.checked;
-            root.toggled(root.checked);
-        }
+        onClicked: root.toggled(!root.checked)
     }
 }


### PR DESCRIPTION
## Summary
- Add a configurable core hours setting (enable toggle + AM/PM-aware start/end dropdowns) that limits day/week views to a set hour range and clips displayed events to it
- Show a warning banner with directional arrows when appointments fall outside core hours, with a one-click disable action
- Fix `DankToggle` so `onClicked` no longer overwrites `root.checked` directly before emitting `toggled()`, which was breaking external bindings (e.g. `checked: SettingsData.someFlag`) after the first click

## Test plan
- [x] Enable core hours in Settings and verify Day/Week views clip to the configured range
- [x] Set events outside the core hours range and confirm the warning banner with directional arrows appears
- [x] Click the warning banner's disable action and confirm core hours turns off
- [x] Toggle a setting bound via `DankToggle` (e.g. core hours enable) multiple times and confirm it stays in sync with external state changes