### PR TITLE
fix: keep calendar window alive to fix tray icon open/close

### DIFF
--- a/quickshell/Modules/CalendarWindow.qml
+++ b/quickshell/Modules/CalendarWindow.qml
@@ -170,7 +170,7 @@ FloatingWindow {
     implicitWidth: 1100
     implicitHeight: screen ? Math.min(820, screen.height - 100) : 820
     color: Theme.surface
-    visible: true
+    visible: Quickshell.env("DANKCAL_START_HIDDEN") !== "1"
 
     onIsCompactModeChanged: {
         if (!isCompactMode)

--- a/quickshell/Modules/TrayIcon.qml
+++ b/quickshell/Modules/TrayIcon.qml
@@ -11,13 +11,13 @@ Item {
     function showWindow() {
         if (!root.shell)
             return;
-        root.shell.handleWindowAction("show");
+        root.shell.handleWindowAction("show", "");
     }
 
     function toggleWindow() {
         if (!root.shell)
             return;
-        root.shell.handleWindowAction("toggle");
+        root.shell.handleWindowAction("toggle", "");
     }
 
     // The SNI item id is read from the application name at registration

--- a/quickshell/shell.qml
+++ b/quickshell/shell.qml
@@ -35,11 +35,8 @@ ShellRoot {
     }
 
     function showAndFocus() {
-        if (windowLoader.active) {
-            focusToplevel();
-            return;
-        }
-        windowLoader.active = true;
+        windowLoader.item.visible = true;
+        focusToplevel();
         focusRetry.restart();
     }
 
@@ -53,11 +50,11 @@ ShellRoot {
             showAndFocus();
             break;
         case "hide":
-            windowLoader.active = false;
+            windowLoader.item.visible = false;
             break;
         case "toggle":
-            if (windowLoader.active) {
-                windowLoader.active = false;
+            if (windowLoader.item.visible) {
+                windowLoader.item.visible = false;
                 return;
             }
             pendingView = view;
@@ -125,10 +122,10 @@ ShellRoot {
 
     LazyLoader {
         id: windowLoader
-        active: Quickshell.env("DANKCAL_START_HIDDEN") !== "1"
+        active: true
 
         CalendarWindow {
-            onHideRequested: windowLoader.active = false
+            onHideRequested: visible = false
         }
     }
 }


### PR DESCRIPTION
## Summary
- Tray icon's "Open Calendar" menu item did nothing once the window had been hidden once, and after that even left-click toggle stopped working.
- Root cause: hide/show was implemented by destroying and recreating the entire `CalendarWindow` via `LazyLoader.active` in `shell.qml`. The teardown (`deleteLater()`) is async while recreation is synchronous, so a fast hide→show cycle could leave a new xdg-toplevel created but never mapped by the compositor — after that, every further toggle just tore it down again with nothing visible happening.
- Fix: keep the window loaded for the app's lifetime and toggle its own `visible` property instead of destroying/recreating it via the loader — the same pattern already used elsewhere in this codebase (e.g. modal loaders) and in DankMaterialShell.
- Also fixes a reproducible `Cannot assign [undefined] to QString` warning: `TrayIcon.qml`'s `showWindow()`/`toggleWindow()` called `handleWindowAction()` without the `view` argument, unlike the IPC path which always passes `""`.

## Test plan
- [x] Reproduced original bug: hide via tray left-click, then "Open Calendar" did nothing, then left-click toggle also did nothing.
- [x] After fix: hide via left-click → "Open Calendar" reopens and focuses the window.
- [x] Repeated hide/show several times rapidly with no stuck state.
- [x] Confirmed the `Cannot assign [undefined] to QString` warning no longer appears.
- [x] Verified manually on a wlroots-based compositor (Hyprland/Sway/niri).