### PR TITLE
assets: Add AppSteam metainfo file

### DIFF
--- a/assets/com.danklinux.dankcalendar.metainfo.xml
+++ b/assets/com.danklinux.dankcalendar.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.danklinux.dankcalendar</id>
+  <launchable type="desktop-id">com.danklinux.dankcalendar.desktop</launchable>
+  <name>DankCalendar</name>
+  <summary>Calendar from the Dank Linux Suite</summary>
+
+  <description>
+    <p>DankCalendar is a standalone calendar app that brings your Local, Google, Microsoft, CalDAV, and iCloud calendars together in one place. It runs as a lightweight daemon with a tray icon, keeps your accounts in sync, and reminds you about events — all with the look and feel of DankMaterialShell.</p>
+  </description>
+
+  <developer id="com.danklinux">
+    <name>Avenge Media LLC</name>
+  </developer>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <url type="homepage">https://danklinux.com</url>
+  <url type="bugtracker">https://github.com/AvengeMedia/dankcalendar/issues</url>
+
+  <content_rating type="oars-1.1" />
+</component>


### PR DESCRIPTION
This file is used by distros (and FlatHub) to create software catalogs that are then used by software centers such as GNOME Software and KDE Discover. Adding this file makes it easier for users to find the project through graphical software centers.

Note that there are other fields that can be added, including other URLs, screenshots, and release notes. I only put in the minimum content that would be needed to successfully be included in the catalog on Solus. FlatHub, if anyone were to persue that, would require a few more.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
