### PR TITLE
Add toggle to collapse the calendar sidebar in non-compact mode

### DIFF
--- a/quickshell/Modules/CalendarWindow.qml
+++ b/quickshell/Modules/CalendarWindow.qml
@@ -30,6 +30,15 @@ FloatingWindow {
             menuVisible = focused;
     }
 
+    readonly property bool sidebarVisible: isCompactMode ? menuVisible : !SettingsData.sidebarCollapsed
+
+    function toggleSidebar() {
+        if (isCompactMode)
+            menuVisible = !menuVisible;
+        else
+            SettingsData.sidebarCollapsed = !SettingsData.sidebarCollapsed;
+    }
+
     readonly property bool eventNavigation: {
         switch (currentView) {
         case "day":
@@ -484,13 +493,12 @@ FloatingWindow {
                     spacing: Theme.spacingM
 
                     DankActionButton {
-                        visible: window.isCompactMode
                         circular: false
                         iconName: "menu"
                         iconSize: Theme.iconSize - 4
                         iconColor: Theme.surfaceText
                         anchors.verticalCenter: parent.verticalCenter
-                        onClicked: window.menuVisible = !window.menuVisible
+                        onClicked: window.toggleSidebar()
                     }
 
                     DankIcon {
@@ -559,7 +567,7 @@ FloatingWindow {
                     anchors.top: parent.top
                     anchors.bottom: parent.bottom
                     width: window.isCompactMode ? parent.width : Math.max(bodyArea.minSidebarWidth, Math.min(bodyArea.maxSidebarWidth, bodyArea.liveSidebarWidth))
-                    visible: window.isCompactMode ? window.menuVisible : true
+                    visible: window.sidebarVisible
                     currentView: window.currentView
                     selectedDate: window.selectedDate
                     keyboardActive: window.sidebarFocused
@@ -583,7 +591,7 @@ FloatingWindow {
                     anchors.bottom: parent.bottom
                     width: Theme.spacingS
                     z: 10
-                    visible: !window.isCompactMode
+                    visible: !window.isCompactMode && window.sidebarVisible
 
                     property bool dragging: false
                     property real pressX: 0
@@ -628,7 +636,7 @@ FloatingWindow {
                 }
 
                 Item {
-                    anchors.left: window.isCompactMode ? (window.menuVisible ? sidebar.right : parent.left) : sidebar.right
+                    anchors.left: window.sidebarVisible ? sidebar.right : parent.left
                     anchors.right: parent.right
                     anchors.top: parent.top
                     anchors.bottom: parent.bottom

--- a/quickshell/Services/SettingsData.qml
+++ b/quickshell/Services/SettingsData.qml
@@ -49,6 +49,8 @@ Singleton {
     property alias closeBehavior: adapter.closeBehavior
     // width of the calendar sidebar in pixels, set by dragging its edge
     property alias sidebarWidth: adapter.sidebarWidth
+    // whether the calendar sidebar is hidden in non-compact mode
+    property alias sidebarCollapsed: adapter.sidebarCollapsed
     // last active calendar view, restored on open: "month" | "week" | "day" | "agenda"
     property alias lastView: adapter.lastView
 
@@ -157,6 +159,7 @@ Singleton {
             property int syncIntervalMinutes: 30
             property string closeBehavior: "minimize"
             property int sidebarWidth: 240
+            property bool sidebarCollapsed: false
             property string lastView: "month"
         }
     }


### PR DESCRIPTION
This pull request improves how the calendar sidebar is shown and hidden, making the sidebar state consistent between compact and non-compact modes and allowing the collapsed state to persist. The sidebar's visibility logic is centralized, and toggling behavior is unified. The sidebar collapsed state is now stored in `SettingsData`, so it persists across sessions.
