### PR TITLE
Add setting to show all events in month view without capping

### DIFF
--- a/quickshell/Modals/SettingsContent.qml
+++ b/quickshell/Modals/SettingsContent.qml
@@ -530,6 +530,17 @@ Item {
                     }
 
                     SettingsRow {
+                        label: I18n.tr("Show all events in month view", "show all month events setting label")
+                        description: I18n.tr("Expand day cells to fit every event instead of collapsing extras into \"+N more\".", "show all month events setting description")
+
+                        DankToggle {
+                            anchors.verticalCenter: parent.verticalCenter
+                            checked: SettingsData.monthShowAllEvents
+                            onToggled: checked => SettingsData.monthShowAllEvents = checked
+                        }
+                    }
+
+                    SettingsRow {
                         label: I18n.tr("Week event title lines", "week event title line count setting label")
                         description: I18n.tr("Maximum title lines per event in week view.", "week event title line count setting description")
 

--- a/quickshell/Modules/views/MonthView.qml
+++ b/quickshell/Modules/views/MonthView.qml
@@ -237,8 +237,10 @@ Item {
                             return upcoming.concat(ended);
                         }
 
-                        // 36px day badge area + 14px reserved for "+N more".
-                        readonly property int maxChips: Math.max(0, Math.min(3, Math.floor((height - 50) / (root.eventChipHeight + 2))))
+                        // When showing all events, chips fill whatever space is available
+                        // below the day badge; otherwise fall back to a 3-chip cap anchored
+                        // at the bottom, matching the classic "+N more" layout.
+                        readonly property int maxChips: SettingsData.monthShowAllEvents ? Math.max(0, Math.floor((height - 36 - Theme.spacingXS * 2 - 14) / (root.eventChipHeight + 2))) : Math.max(0, Math.min(3, Math.floor((height - 50) / (root.eventChipHeight + 2))))
 
                         width: grid.cellWidth
                         height: grid.cellHeight
@@ -305,7 +307,8 @@ Item {
                         Column {
                             anchors.left: parent.left
                             anchors.right: parent.right
-                            anchors.bottom: parent.bottom
+                            anchors.top: SettingsData.monthShowAllEvents ? dayBadge.bottom : undefined
+                            anchors.bottom: SettingsData.monthShowAllEvents ? undefined : parent.bottom
                             anchors.margins: Theme.spacingXS
                             spacing: 2
                             clip: true

--- a/quickshell/Services/SettingsData.qml
+++ b/quickshell/Services/SettingsData.qml
@@ -33,6 +33,7 @@ Singleton {
     property alias showWeekNumbers: adapter.showWeekNumbers
     property alias showTasks: adapter.showTasks
     property alias monthEventTitleLines: adapter.monthEventTitleLines
+    property alias monthShowAllEvents: adapter.monthShowAllEvents
     property alias weekEventTitleLines: adapter.weekEventTitleLines
     property alias defaultEventDurationMinutes: adapter.defaultEventDurationMinutes
     // -1 = no reminder
@@ -145,6 +146,7 @@ Singleton {
             property bool showWeekNumbers: false
             property bool showTasks: true
             property int monthEventTitleLines: 1
+            property bool monthShowAllEvents: false
             property int weekEventTitleLines: 1
             property int defaultEventDurationMinutes: 30
             property int defaultReminderMinutes: 10

--- a/quickshell/translations/en.json
+++ b/quickshell/translations/en.json
@@ -74,7 +74,7 @@
   {
     "term": "+%1 more",
     "context": "+%1 more",
-    "reference": "Modules/views/MonthView.qml:374",
+    "reference": "Modules/views/MonthView.qml:377",
     "comment": "overflow label in month grid day cell, %1 is the number of hidden events"
   },
   {
@@ -86,7 +86,7 @@
   {
     "term": "1 day before",
     "context": "1 day before",
-    "reference": "Modals/EventDetailsModal.qml:66, Modals/SettingsContent.qml:189, Modals/CalendarRemindersDialog.qml:81",
+    "reference": "Modals/CalendarRemindersDialog.qml:81, Modals/EventDetailsModal.qml:66, Modals/SettingsContent.qml:189",
     "comment": "all-day reminder day dropdown option | event reminder dropdown option"
   },
   {
@@ -98,7 +98,7 @@
   {
     "term": "1 hour before",
     "context": "1 hour before",
-    "reference": "Modals/EventDetailsModal.qml:58, Modals/SettingsContent.qml:159, Modals/CalendarRemindersDialog.qml:53",
+    "reference": "Modals/CalendarRemindersDialog.qml:53, Modals/EventDetailsModal.qml:58, Modals/SettingsContent.qml:159",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -116,7 +116,7 @@
   {
     "term": "1 week before",
     "context": "1 week before",
-    "reference": "Modals/EventDetailsModal.qml:74, Modals/SettingsContent.qml:197, Modals/CalendarRemindersDialog.qml:89",
+    "reference": "Modals/CalendarRemindersDialog.qml:89, Modals/EventDetailsModal.qml:74, Modals/SettingsContent.qml:197",
     "comment": "all-day reminder day dropdown option | event reminder dropdown option"
   },
   {
@@ -128,13 +128,13 @@
   {
     "term": "10 minutes",
     "context": "10 minutes",
-    "reference": "Modals/SettingsContent.qml:170, Modals/CalendarRemindersDialog.qml:63",
+    "reference": "Modals/CalendarRemindersDialog.qml:63, Modals/SettingsContent.qml:170",
     "comment": "snooze duration dropdown option"
   },
   {
     "term": "10 minutes before",
     "context": "10 minutes before",
-    "reference": "Modals/EventDetailsModal.qml:46, Modals/SettingsContent.qml:147, Modals/CalendarRemindersDialog.qml:41",
+    "reference": "Modals/CalendarRemindersDialog.qml:41, Modals/EventDetailsModal.qml:46, Modals/SettingsContent.qml:147",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -152,19 +152,19 @@
   {
     "term": "15 minutes",
     "context": "15 minutes",
-    "reference": "Modals/SettingsContent.qml:77, Modals/SettingsContent.qml:174, Modals/SettingsContent.qml:212, Modals/CalendarRemindersDialog.qml:67",
+    "reference": "Modals/CalendarRemindersDialog.qml:67, Modals/SettingsContent.qml:77, Modals/SettingsContent.qml:174, Modals/SettingsContent.qml:212",
     "comment": "default event duration option | snooze duration dropdown option | sync interval dropdown option"
   },
   {
     "term": "15 minutes before",
     "context": "15 minutes before",
-    "reference": "Modals/EventDetailsModal.qml:50, Modals/SettingsContent.qml:151, Modals/CalendarRemindersDialog.qml:45",
+    "reference": "Modals/CalendarRemindersDialog.qml:45, Modals/EventDetailsModal.qml:50, Modals/SettingsContent.qml:151",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
     "term": "2 days before",
     "context": "2 days before",
-    "reference": "Modals/EventDetailsModal.qml:70, Modals/SettingsContent.qml:193, Modals/CalendarRemindersDialog.qml:85",
+    "reference": "Modals/CalendarRemindersDialog.qml:85, Modals/EventDetailsModal.qml:70, Modals/SettingsContent.qml:193",
     "comment": "all-day reminder day dropdown option | event reminder dropdown option"
   },
   {
@@ -206,13 +206,13 @@
   {
     "term": "30 minutes",
     "context": "30 minutes",
-    "reference": "Modals/SettingsContent.qml:81, Modals/SettingsContent.qml:178, Modals/SettingsContent.qml:216, Modals/CalendarRemindersDialog.qml:71",
+    "reference": "Modals/CalendarRemindersDialog.qml:71, Modals/SettingsContent.qml:81, Modals/SettingsContent.qml:178, Modals/SettingsContent.qml:216",
     "comment": "default event duration option | snooze duration dropdown option | sync interval dropdown option"
   },
   {
     "term": "30 minutes before",
     "context": "30 minutes before",
-    "reference": "Modals/EventDetailsModal.qml:54, Modals/SettingsContent.qml:155, Modals/CalendarRemindersDialog.qml:49",
+    "reference": "Modals/CalendarRemindersDialog.qml:49, Modals/EventDetailsModal.qml:54, Modals/SettingsContent.qml:155",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -224,13 +224,13 @@
   {
     "term": "5 minutes",
     "context": "5 minutes",
-    "reference": "Modals/SettingsContent.qml:166, Modals/SettingsContent.qml:208, Modals/CalendarRemindersDialog.qml:59",
+    "reference": "Modals/CalendarRemindersDialog.qml:59, Modals/SettingsContent.qml:166, Modals/SettingsContent.qml:208",
     "comment": "snooze duration dropdown option | sync interval dropdown option"
   },
   {
     "term": "5 minutes before",
     "context": "5 minutes before",
-    "reference": "Modals/EventDetailsModal.qml:42, Modals/SettingsContent.qml:143, Modals/CalendarRemindersDialog.qml:37",
+    "reference": "Modals/CalendarRemindersDialog.qml:37, Modals/EventDetailsModal.qml:42, Modals/SettingsContent.qml:143",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -260,7 +260,7 @@
   {
     "term": "About",
     "context": "About",
-    "reference": "Modals/SettingsSidebar.qml:35, Modals/SettingsAboutPage.qml:233",
+    "reference": "Modals/SettingsAboutPage.qml:233, Modals/SettingsSidebar.qml:35",
     "comment": "about page project section header | settings sidebar tab label"
   },
   {
@@ -284,7 +284,7 @@
   {
     "term": "Accounts",
     "context": "Accounts",
-    "reference": "Modules/CalendarSidebar.qml:795, Modals/SettingsSidebar.qml:27, Modals/SettingsContent.qml:1073",
+    "reference": "Modals/SettingsSidebar.qml:27, Modals/SettingsContent.qml:1084, Modules/CalendarSidebar.qml:795",
     "comment": "accounts settings section header | settings sidebar tab label | sidebar section header for the account list"
   },
   {
@@ -308,7 +308,7 @@
   {
     "term": "Add account",
     "context": "Add account",
-    "reference": "Modules/CalendarSidebar.qml:952, Modals/AccountAddModal.qml:213, Modals/AccountAddModal.qml:305, Modals/SettingsContent.qml:1211",
+    "reference": "Modals/AccountAddModal.qml:213, Modals/AccountAddModal.qml:305, Modals/SettingsContent.qml:1222, Modules/CalendarSidebar.qml:952",
     "comment": "account add modal header title | account add modal window title | add account button on accounts page | sidebar button to add a provider account"
   },
   {
@@ -344,7 +344,7 @@
   {
     "term": "Agenda",
     "context": "Agenda",
-    "reference": "Modules/CalendarSidebar.qml:49, Modules/CalendarContent.qml:36",
+    "reference": "Modules/CalendarContent.qml:36, Modules/CalendarSidebar.qml:49",
     "comment": "header title when the agenda view is active | view switcher option in sidebar"
   },
   {
@@ -362,7 +362,7 @@
   {
     "term": "All day",
     "context": "All day",
-    "reference": "Modals/EventDetailsModal.qml:929, Modals/SearchModal.qml:80, Modules/views/AgendaView.qml:72, Modules/views/DayView.qml:54, Modules/views/WeekView.qml:79, Modules/views/MonthView.qml:98, Modules/views/MonthDayPopover.qml:157",
+    "reference": "Modals/EventDetailsModal.qml:929, Modals/SearchModal.qml:80, Modules/views/AgendaView.qml:72, Modules/views/DayView.qml:54, Modules/views/MonthDayPopover.qml:157, Modules/views/WeekView.qml:79, Modules/views/MonthView.qml:98",
     "comment": "all-day marker in event tooltip | all-day marker in the month day-detail popover | event form toggle label for all-day events | search result subtitle for all-day events | time column label for all-day events on agenda card"
   },
   {
@@ -374,7 +374,7 @@
   {
     "term": "All-day reminder time",
     "context": "All-day reminder time",
-    "reference": "Modals/SettingsContent.qml:1304",
+    "reference": "Modals/SettingsContent.qml:1315",
     "comment": "all-day reminder time setting label"
   },
   {
@@ -392,13 +392,13 @@
   {
     "term": "Always use the dark theme.",
     "context": "Always use the dark theme.",
-    "reference": "Modals/SettingsContent.qml:626",
+    "reference": "Modals/SettingsContent.qml:637",
     "comment": "theme mode setting description"
   },
   {
     "term": "Always use the light theme.",
     "context": "Always use the light theme.",
-    "reference": "Modals/SettingsContent.qml:624",
+    "reference": "Modals/SettingsContent.qml:635",
     "comment": "theme mode setting description"
   },
   {
@@ -410,7 +410,7 @@
   {
     "term": "Appearance",
     "context": "Appearance",
-    "reference": "Modals/SettingsSidebar.qml:19, Modals/SettingsContent.qml:611",
+    "reference": "Modals/SettingsSidebar.qml:19, Modals/SettingsContent.qml:622",
     "comment": "appearance settings section header | settings sidebar tab label"
   },
   {
@@ -440,7 +440,7 @@
   {
     "term": "At start",
     "context": "At start",
-    "reference": "Modals/EventDetailsModal.qml:38, Modals/EventDetailsModal.qml:169, Modals/SettingsContent.qml:139, Modals/CalendarRemindersDialog.qml:33",
+    "reference": "Modals/CalendarRemindersDialog.qml:33, Modals/EventDetailsModal.qml:38, Modals/EventDetailsModal.qml:169, Modals/SettingsContent.qml:139",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -464,7 +464,7 @@
   {
     "term": "Auto",
     "context": "Auto",
-    "reference": "Modals/SettingsContent.qml:16, Modals/SettingsContent.qml:425, Modals/SettingsContent.qml:636",
+    "reference": "Modals/SettingsContent.qml:16, Modals/SettingsContent.qml:425, Modals/SettingsContent.qml:647",
     "comment": "color source button group option following DMS | theme mode button group option | time format button group option"
   },
   {
@@ -494,7 +494,7 @@
   {
     "term": "Backend not connected.",
     "context": "Backend not connected.",
-    "reference": "Modals/SettingsContent.qml:887, Modals/SettingsContent.qml:1074, Modals/SettingsContent.qml:1329",
+    "reference": "Modals/SettingsContent.qml:898, Modals/SettingsContent.qml:1085, Modals/SettingsContent.qml:1340",
     "comment": "accounts settings section subtitle | calendars page empty state | test notification setting description when backend is unavailable"
   },
   {
@@ -524,7 +524,7 @@
   {
     "term": "Calendars",
     "context": "Calendars",
-    "reference": "Modals/SettingsSidebar.qml:23, Modals/SettingsContent.qml:877",
+    "reference": "Modals/SettingsSidebar.qml:23, Modals/SettingsContent.qml:888",
     "comment": "calendars settings section header | settings sidebar tab label"
   },
   {
@@ -536,7 +536,7 @@
   {
     "term": "Cancel",
     "context": "Cancel",
-    "reference": "Modals/ConfirmDialog.qml:71, Modals/EventDetailsModal.qml:523, Modals/NewCalendarDialog.qml:100, Modals/RenameCalendarDialog.qml:97, Modals/TaskDetailsModal.qml:497, Modals/AccountAddModal.qml:1096, Modals/CalendarRemindersDialog.qml:375, Modals/FileBrowser/FileBrowserOverwriteDialog.qml:83",
+    "reference": "Modals/AccountAddModal.qml:1096, Modals/CalendarRemindersDialog.qml:375, Modals/ConfirmDialog.qml:71, Modals/EventDetailsModal.qml:523, Modals/NewCalendarDialog.qml:100, Modals/RenameCalendarDialog.qml:97, Modals/TaskDetailsModal.qml:497, Modals/FileBrowser/FileBrowserOverwriteDialog.qml:83",
     "comment": "button to cancel oauth browser step | confirm dialog button to cancel | event form button to cancel editing | file browser overwrite dialog cancel button | new calendar dialog button to cancel | per-calendar reminders dialog button to cancel | rename calendar dialog button to cancel | task form button to discard changes"
   },
   {
@@ -548,7 +548,7 @@
   {
     "term": "Choose a JSON color theme file.",
     "context": "Choose a JSON color theme file.",
-    "reference": "Modals/SettingsContent.qml:829",
+    "reference": "Modals/SettingsContent.qml:840",
     "comment": "custom theme hint when none selected"
   },
   {
@@ -602,7 +602,7 @@
   {
     "term": "Color source",
     "context": "Color source",
-    "reference": "Modals/SettingsContent.qml:666",
+    "reference": "Modals/SettingsContent.qml:677",
     "comment": "color source setting label"
   },
   {
@@ -650,13 +650,13 @@
   {
     "term": "Connected",
     "context": "Connected",
-    "reference": "Modals/AccountAddModal.qml:1138, Modals/SettingsContent.qml:1149, Modals/SettingsAboutPage.qml:365",
+    "reference": "Modals/AccountAddModal.qml:1138, Modals/SettingsAboutPage.qml:365, Modals/SettingsContent.qml:1160",
     "comment": "about page daemon status value | account status in account list | success step status heading"
   },
   {
     "term": "Connected calendar providers.",
     "context": "Connected calendar providers.",
-    "reference": "Modals/SettingsContent.qml:1074",
+    "reference": "Modals/SettingsContent.qml:1085",
     "comment": "accounts settings section subtitle"
   },
   {
@@ -698,7 +698,7 @@
   {
     "term": "Could not read that file — expected a JSON color theme.",
     "context": "Could not read that file — expected a JSON color theme.",
-    "reference": "Modals/SettingsContent.qml:832",
+    "reference": "Modals/SettingsContent.qml:843",
     "comment": "custom theme error when file is invalid"
   },
   {
@@ -722,7 +722,7 @@
   {
     "term": "Create event",
     "context": "Create event",
-    "reference": "Modules/CalendarSidebar.qml:417, Modals/KeyboardShortcutsOverlay.qml:123",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:123, Modules/CalendarSidebar.qml:417",
     "comment": "keyboard shortcut description | sidebar button to create a new event"
   },
   {
@@ -764,13 +764,13 @@
   {
     "term": "DankMaterialShell not detected — using the %1 preset.",
     "context": "DankMaterialShell not detected — using the %1 preset.",
-    "reference": "Modals/SettingsContent.qml:722",
+    "reference": "Modals/SettingsContent.qml:733",
     "comment": "auto color source status when DMS is missing"
   },
   {
     "term": "Dark",
     "context": "Dark",
-    "reference": "Modals/SettingsContent.qml:636",
+    "reference": "Modals/SettingsContent.qml:647",
     "comment": "theme mode button group option"
   },
   {
@@ -794,13 +794,13 @@
   {
     "term": "Default event duration",
     "context": "Default event duration",
-    "reference": "Modals/SettingsContent.qml:546",
+    "reference": "Modals/SettingsContent.qml:557",
     "comment": "default event duration setting label"
   },
   {
     "term": "Default reminder",
     "context": "Default reminder",
-    "reference": "Modals/SettingsContent.qml:559, Modals/CalendarRemindersDialog.qml:296",
+    "reference": "Modals/CalendarRemindersDialog.qml:296, Modals/SettingsContent.qml:570",
     "comment": "default reminder setting label | per-calendar default reminder override label"
   },
   {
@@ -812,13 +812,13 @@
   {
     "term": "Delete",
     "context": "Delete",
-    "reference": "Modules/CalendarSidebar.qml:300, Modals/TaskDetailsModal.qml:487, Modals/SettingsContent.qml:979",
+    "reference": "Modals/TaskDetailsModal.qml:487, Modals/SettingsContent.qml:990, Modules/CalendarSidebar.qml:300",
     "comment": "confirm button for deleting a calendar | delete calendar confirmation button | task form button to delete the task"
   },
   {
     "term": "Delete \"%1\"?",
     "context": "Delete \"%1\"?",
-    "reference": "Modules/CalendarSidebar.qml:298, Modals/SettingsContent.qml:977",
+    "reference": "Modals/SettingsContent.qml:988, Modules/CalendarSidebar.qml:298",
     "comment": "confirm dialog title for deleting a calendar, %1 is the calendar name | delete calendar confirmation title"
   },
   {
@@ -848,7 +848,7 @@
   {
     "term": "Desktop notifications for upcoming events.",
     "context": "Desktop notifications for upcoming events.",
-    "reference": "Modals/SettingsContent.qml:1255",
+    "reference": "Modals/SettingsContent.qml:1266",
     "comment": "reminders toggle description"
   },
   {
@@ -938,7 +938,7 @@
   {
     "term": "Enable reminders",
     "context": "Enable reminders",
-    "reference": "Modals/SettingsContent.qml:1254, Modals/CalendarRemindersDialog.qml:272",
+    "reference": "Modals/CalendarRemindersDialog.qml:272, Modals/SettingsContent.qml:1265",
     "comment": "per-calendar enable reminders override label | reminders toggle label"
   },
   {
@@ -1002,6 +1002,12 @@
     "comment": "evolution account display name field placeholder"
   },
   {
+    "term": "Expand day cells to fit every event instead of collapsing extras into \"+N more\".",
+    "context": "Expand day cells to fit every event instead of collapsing extras into \"+N more\".",
+    "reference": "Modals/SettingsContent.qml:534",
+    "comment": "show all month events setting description"
+  },
+  {
     "term": "F1/I: Toggle • F10: Help",
     "context": "F1/I: Toggle • F10: Help",
     "reference": "Modals/FileBrowser/FileInfo.qml:199",
@@ -1046,19 +1052,19 @@
   {
     "term": "Follow DankMaterialShell colors, falling back to a preset.",
     "context": "Follow DankMaterialShell colors, falling back to a preset.",
-    "reference": "Modals/SettingsContent.qml:674",
+    "reference": "Modals/SettingsContent.qml:685",
     "comment": "color source description for auto"
   },
   {
     "term": "Following the system color scheme (currently %1).",
     "context": "Following the system color scheme (currently %1).",
-    "reference": "Modals/SettingsContent.qml:628",
+    "reference": "Modals/SettingsContent.qml:639",
     "comment": "theme mode setting description"
   },
   {
     "term": "General",
     "context": "General",
-    "reference": "Modals/SettingsSidebar.qml:15, Modals/SettingsContent.qml:366, Modals/KeyboardShortcutsOverlay.qml:119",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:119, Modals/SettingsSidebar.qml:15, Modals/SettingsContent.qml:366",
     "comment": "general settings section header | keyboard shortcuts overlay section header | settings sidebar tab label"
   },
   {
@@ -1118,13 +1124,13 @@
   {
     "term": "How long the snooze button postpones a reminder.",
     "context": "How long the snooze button postpones a reminder.",
-    "reference": "Modals/SettingsContent.qml:1278",
+    "reference": "Modals/SettingsContent.qml:1289",
     "comment": "snooze duration setting description"
   },
   {
     "term": "How often accounts are polled for changes.",
     "context": "How often accounts are polled for changes.",
-    "reference": "Modals/SettingsContent.qml:573",
+    "reference": "Modals/SettingsContent.qml:584",
     "comment": "sync interval setting description"
   },
   {
@@ -1142,7 +1148,7 @@
   {
     "term": "Initial reminder set on new events.",
     "context": "Initial reminder set on new events.",
-    "reference": "Modals/SettingsContent.qml:560",
+    "reference": "Modals/SettingsContent.qml:571",
     "comment": "default reminder setting description"
   },
   {
@@ -1160,7 +1166,7 @@
   {
     "term": "Keep until dismissed",
     "context": "Keep until dismissed",
-    "reference": "Modals/SettingsContent.qml:1265, Modals/CalendarRemindersDialog.qml:284",
+    "reference": "Modals/CalendarRemindersDialog.qml:284, Modals/SettingsContent.qml:1276",
     "comment": "per-calendar persist override label | persistent reminders toggle label"
   },
   {
@@ -1184,13 +1190,13 @@
   {
     "term": "Length used when creating events.",
     "context": "Length used when creating events.",
-    "reference": "Modals/SettingsContent.qml:547",
+    "reference": "Modals/SettingsContent.qml:558",
     "comment": "default event duration setting description"
   },
   {
     "term": "Light",
     "context": "Light",
-    "reference": "Modals/SettingsContent.qml:636",
+    "reference": "Modals/SettingsContent.qml:647",
     "comment": "theme mode button group option"
   },
   {
@@ -1208,7 +1214,7 @@
   {
     "term": "Load colors from your own theme file.",
     "context": "Load colors from your own theme file.",
-    "reference": "Modals/SettingsContent.qml:672",
+    "reference": "Modals/SettingsContent.qml:683",
     "comment": "color source description for custom"
   },
   {
@@ -1220,7 +1226,7 @@
   {
     "term": "Local",
     "context": "Local",
-    "reference": "Modals/AccountAddModal.qml:120, Modals/AccountAddModal.qml:511, Modals/SettingsContent.qml:1054, Services/DankCalService.qml:1421",
+    "reference": "Modals/AccountAddModal.qml:120, Modals/AccountAddModal.qml:511, Modals/SettingsContent.qml:1065, Services/DankCalService.qml:1421",
     "comment": "local provider name in account add modal | local provider name in account list | provider label for a local account"
   },
   {
@@ -1262,7 +1268,7 @@
   {
     "term": "Maximum title lines per event in week view.",
     "context": "Maximum title lines per event in week view.",
-    "reference": "Modals/SettingsContent.qml:534",
+    "reference": "Modals/SettingsContent.qml:545",
     "comment": "week event title line count setting description"
   },
   {
@@ -1430,7 +1436,7 @@
   {
     "term": "No accounts yet. Click \"Add account\" to connect one.",
     "context": "No accounts yet. Click \"Add account\" to connect one.",
-    "reference": "Modals/SettingsContent.qml:1083",
+    "reference": "Modals/SettingsContent.qml:1094",
     "comment": "accounts page empty state"
   },
   {
@@ -1442,7 +1448,7 @@
   {
     "term": "No calendars yet. Add an account first.",
     "context": "No calendars yet. Add an account first.",
-    "reference": "Modals/SettingsContent.qml:887",
+    "reference": "Modals/SettingsContent.qml:898",
     "comment": "calendars page empty state"
   },
   {
@@ -1478,7 +1484,7 @@
   {
     "term": "No theme file selected",
     "context": "No theme file selected",
-    "reference": "Modals/SettingsContent.qml:818",
+    "reference": "Modals/SettingsContent.qml:829",
     "comment": "custom theme empty state title"
   },
   {
@@ -1490,13 +1496,13 @@
   {
     "term": "None",
     "context": "None",
-    "reference": "Modals/EventDetailsModal.qml:34, Modals/TaskDetailsModal.qml:66, Modals/SettingsContent.qml:135, Modals/CalendarRemindersDialog.qml:29",
+    "reference": "Modals/CalendarRemindersDialog.qml:29, Modals/EventDetailsModal.qml:34, Modals/TaskDetailsModal.qml:66, Modals/SettingsContent.qml:135",
     "comment": "default reminder dropdown option | event reminder dropdown option | task priority dropdown option"
   },
   {
     "term": "Not authorized — remove this account and add it again",
     "context": "Not authorized — remove this account and add it again",
-    "reference": "Modals/SettingsContent.qml:1149",
+    "reference": "Modals/SettingsContent.qml:1160",
     "comment": "account status in account list"
   },
   {
@@ -1520,13 +1526,13 @@
   {
     "term": "Notifications",
     "context": "Notifications",
-    "reference": "Modals/SettingsSidebar.qml:31, Modals/SettingsContent.qml:1245",
+    "reference": "Modals/SettingsSidebar.qml:31, Modals/SettingsContent.qml:1256",
     "comment": "notifications settings section header | settings sidebar tab label"
   },
   {
     "term": "Notify for all-day events without their own reminders.",
     "context": "Notify for all-day events without their own reminders.",
-    "reference": "Modals/SettingsContent.qml:1293",
+    "reference": "Modals/SettingsContent.qml:1304",
     "comment": "all-day reminders toggle description"
   },
   {
@@ -1538,7 +1544,7 @@
   {
     "term": "On the day",
     "context": "On the day",
-    "reference": "Modals/SettingsContent.qml:185, Modals/CalendarRemindersDialog.qml:77",
+    "reference": "Modals/CalendarRemindersDialog.qml:77, Modals/SettingsContent.qml:185",
     "comment": "all-day reminder day dropdown option"
   },
   {
@@ -1604,7 +1610,7 @@
   {
     "term": "Palette: %1",
     "context": "Palette: %1",
-    "reference": "Modals/SettingsContent.qml:747",
+    "reference": "Modals/SettingsContent.qml:758",
     "comment": "selected preset palette name"
   },
   {
@@ -1652,7 +1658,7 @@
   {
     "term": "Pick a color source, palette, or your own theme file.",
     "context": "Pick a color source, palette, or your own theme file.",
-    "reference": "Modals/SettingsContent.qml:612",
+    "reference": "Modals/SettingsContent.qml:623",
     "comment": "appearance settings section subtitle"
   },
   {
@@ -1712,7 +1718,7 @@
   {
     "term": "Quit",
     "context": "Quit",
-    "reference": "Modules/TrayIcon.qml:57, Modals/SettingsContent.qml:394",
+    "reference": "Modals/SettingsContent.qml:394, Modules/TrayIcon.qml:57",
     "comment": "close behavior button group option to quit the app | tray menu item to quit the application"
   },
   {
@@ -1730,7 +1736,7 @@
   {
     "term": "Reminders and desktop alerts.",
     "context": "Reminders and desktop alerts.",
-    "reference": "Modals/SettingsContent.qml:1246",
+    "reference": "Modals/SettingsContent.qml:1257",
     "comment": "notifications settings section subtitle"
   },
   {
@@ -1748,19 +1754,19 @@
   {
     "term": "Reminders stay on screen until you act on them.",
     "context": "Reminders stay on screen until you act on them.",
-    "reference": "Modals/SettingsContent.qml:1266",
+    "reference": "Modals/SettingsContent.qml:1277",
     "comment": "persistent reminders toggle description"
   },
   {
     "term": "Remove",
     "context": "Remove",
-    "reference": "Modules/CalendarSidebar.qml:311, Modals/SettingsContent.qml:1200",
+    "reference": "Modals/SettingsContent.qml:1211, Modules/CalendarSidebar.qml:311",
     "comment": "confirm button for removing an account | remove account confirmation button"
   },
   {
     "term": "Remove \"%1\"?",
     "context": "Remove \"%1\"?",
-    "reference": "Modules/CalendarSidebar.qml:309, Modals/SettingsContent.qml:1198",
+    "reference": "Modals/SettingsContent.qml:1209, Modules/CalendarSidebar.qml:309",
     "comment": "confirm dialog title for removing an account, %1 is the account label | remove account confirmation title"
   },
   {
@@ -1772,13 +1778,13 @@
   {
     "term": "Removes this account and its calendars and events from Dank Calendar. Nothing is deleted from the provider.",
     "context": "Removes this account and its calendars and events from Dank Calendar. Nothing is deleted from the provider.",
-    "reference": "Modules/CalendarSidebar.qml:310, Modals/SettingsContent.qml:1199",
+    "reference": "Modals/SettingsContent.qml:1210, Modules/CalendarSidebar.qml:310",
     "comment": "confirm dialog body for removing an account | remove account confirmation message"
   },
   {
     "term": "Removes this calendar and its events from Dank Calendar. If the provider still offers it, it will come back on the next sync.",
     "context": "Removes this calendar and its events from Dank Calendar. If the provider still offers it, it will come back on the next sync.",
-    "reference": "Modules/CalendarSidebar.qml:299, Modals/SettingsContent.qml:978",
+    "reference": "Modals/SettingsContent.qml:989, Modules/CalendarSidebar.qml:299",
     "comment": "confirm dialog body for deleting a calendar | delete calendar confirmation message"
   },
   {
@@ -1790,7 +1796,7 @@
   {
     "term": "Rename calendar",
     "context": "Rename calendar",
-    "reference": "Modals/RenameCalendarDialog.qml:59, Modals/KeyboardShortcutsOverlay.qml:110",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:110, Modals/RenameCalendarDialog.qml:59",
     "comment": "keyboard shortcut description | rename calendar dialog header"
   },
   {
@@ -1832,7 +1838,7 @@
   {
     "term": "Save",
     "context": "Save",
-    "reference": "Modals/EventDetailsModal.qml:537, Modals/RenameCalendarDialog.qml:104, Modals/TaskDetailsModal.qml:506, Modals/CalendarRemindersDialog.qml:382, Modals/FileBrowser/FileBrowserSaveRow.qml:59",
+    "reference": "Modals/CalendarRemindersDialog.qml:382, Modals/EventDetailsModal.qml:537, Modals/RenameCalendarDialog.qml:104, Modals/TaskDetailsModal.qml:506, Modals/FileBrowser/FileBrowserSaveRow.qml:59",
     "comment": "event details button to save changes | file browser save button | per-calendar reminders dialog button to save | rename calendar dialog button to save name | task form button to persist the task"
   },
   {
@@ -1886,13 +1892,13 @@
   {
     "term": "Select theme file",
     "context": "Select theme file",
-    "reference": "Modals/SettingsContent.qml:599",
+    "reference": "Modals/SettingsContent.qml:610",
     "comment": "custom theme file picker title"
   },
   {
     "term": "Send test",
     "context": "Send test",
-    "reference": "Modals/SettingsContent.qml:1333",
+    "reference": "Modals/SettingsContent.qml:1344",
     "comment": "test notification button"
   },
   {
@@ -1904,7 +1910,7 @@
   {
     "term": "Settings",
     "context": "Settings",
-    "reference": "Modals/SettingsModal.qml:86, Modals/KeyboardShortcutsOverlay.qml:131",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:131, Modals/SettingsModal.qml:86",
     "comment": "keyboard shortcut description | settings window header title"
   },
   {
@@ -1914,9 +1920,15 @@
     "comment": "calendar context menu action to show a hidden calendar"
   },
   {
+    "term": "Show all events in month view",
+    "context": "Show all events in month view",
+    "reference": "Modals/SettingsContent.qml:533",
+    "comment": "show all month events setting label"
+  },
+  {
     "term": "Show all-day reminders",
     "context": "Show all-day reminders",
-    "reference": "Modals/SettingsContent.qml:1292, Modals/CalendarRemindersDialog.qml:322",
+    "reference": "Modals/CalendarRemindersDialog.qml:322, Modals/SettingsContent.qml:1303",
     "comment": "all-day reminders toggle label | per-calendar all-day reminders override label"
   },
   {
@@ -1970,7 +1982,7 @@
   {
     "term": "Sign-in expired — reconnect to keep syncing",
     "context": "Sign-in expired — reconnect to keep syncing",
-    "reference": "Modals/SettingsContent.qml:1149",
+    "reference": "Modals/SettingsContent.qml:1160",
     "comment": "account status when oauth needs re-auth"
   },
   {
@@ -1982,7 +1994,7 @@
   {
     "term": "Snooze duration",
     "context": "Snooze duration",
-    "reference": "Modals/SettingsContent.qml:1277, Modals/CalendarRemindersDialog.qml:309",
+    "reference": "Modals/CalendarRemindersDialog.qml:309, Modals/SettingsContent.qml:1288",
     "comment": "per-calendar snooze override label | snooze duration setting label"
   },
   {
@@ -2048,7 +2060,7 @@
   {
     "term": "Sync interval",
     "context": "Sync interval",
-    "reference": "Modals/SettingsContent.qml:572",
+    "reference": "Modals/SettingsContent.qml:583",
     "comment": "sync interval setting label"
   },
   {
@@ -2072,7 +2084,7 @@
   {
     "term": "System preference unavailable — using dark.",
     "context": "System preference unavailable — using dark.",
-    "reference": "Modals/SettingsContent.qml:628",
+    "reference": "Modals/SettingsContent.qml:639",
     "comment": "theme mode setting description"
   },
   {
@@ -2102,7 +2114,7 @@
   {
     "term": "Tasks",
     "context": "Tasks",
-    "reference": "Modules/CalendarSidebar.qml:56, Modules/CalendarSidebar.qml:657, Modules/CalendarContent.qml:38",
+    "reference": "Modules/CalendarContent.qml:38, Modules/CalendarSidebar.qml:56, Modules/CalendarSidebar.qml:657",
     "comment": "header title when the tasks view is active | sidebar section header for the task list | view switcher option in sidebar"
   },
   {
@@ -2114,7 +2126,7 @@
   {
     "term": "Test notification",
     "context": "Test notification",
-    "reference": "Modals/SettingsContent.qml:1328",
+    "reference": "Modals/SettingsContent.qml:1339",
     "comment": "test notification setting label"
   },
   {
@@ -2126,7 +2138,7 @@
   {
     "term": "Theme",
     "context": "Theme",
-    "reference": "Modals/SettingsContent.qml:620",
+    "reference": "Modals/SettingsContent.qml:631",
     "comment": "theme mode setting label"
   },
   {
@@ -2150,7 +2162,7 @@
   {
     "term": "Today",
     "context": "Today",
-    "reference": "Modules/CalendarContent.qml:59, Modals/SearchModal.qml:69, Modules/views/AgendaView.qml:41, Modules/views/TasksView.qml:31, Modules/views/TasksView.qml:52",
+    "reference": "Modals/SearchModal.qml:69, Modules/CalendarContent.qml:59, Modules/views/AgendaView.qml:41, Modules/views/TasksView.qml:31, Modules/views/TasksView.qml:52",
     "comment": "agenda section header for the current day | due-date label on a task card | header button that jumps to the current date | search result date label for current day | tasks view section header for tasks due today"
   },
   {
@@ -2216,7 +2228,7 @@
   {
     "term": "Use a bundled color palette.",
     "context": "Use a bundled color palette.",
-    "reference": "Modals/SettingsContent.qml:670",
+    "reference": "Modals/SettingsContent.qml:681",
     "comment": "color source description for preset"
   },
   {
@@ -2252,13 +2264,13 @@
   {
     "term": "Using DankMaterialShell dynamic colors.",
     "context": "Using DankMaterialShell dynamic colors.",
-    "reference": "Modals/SettingsContent.qml:722",
+    "reference": "Modals/SettingsContent.qml:733",
     "comment": "auto color source status when DMS is active"
   },
   {
     "term": "Verify desktop notifications are working.",
     "context": "Verify desktop notifications are working.",
-    "reference": "Modals/SettingsContent.qml:1329",
+    "reference": "Modals/SettingsContent.qml:1340",
     "comment": "test notification setting description"
   },
   {
@@ -2282,7 +2294,7 @@
   {
     "term": "Visibility, names, and removal per calendar.",
     "context": "Visibility, names, and removal per calendar.",
-    "reference": "Modals/SettingsContent.qml:878",
+    "reference": "Modals/SettingsContent.qml:889",
     "comment": "calendars settings section subtitle"
   },
   {
@@ -2306,7 +2318,7 @@
   {
     "term": "Week event title lines",
     "context": "Week event title lines",
-    "reference": "Modals/SettingsContent.qml:533",
+    "reference": "Modals/SettingsContent.qml:544",
     "comment": "week event title line count setting label"
   },
   {
@@ -2330,7 +2342,7 @@
   {
     "term": "When all-day event reminders fire.",
     "context": "When all-day event reminders fire.",
-    "reference": "Modals/SettingsContent.qml:1305",
+    "reference": "Modals/SettingsContent.qml:1316",
     "comment": "all-day reminder time setting description"
   },
   {
@@ -2372,7 +2384,7 @@
   {
     "term": "dark",
     "context": "dark",
-    "reference": "Modals/SettingsContent.qml:628",
+    "reference": "Modals/SettingsContent.qml:639",
     "comment": "current scheme name in theme mode description"
   },
   {
@@ -2396,7 +2408,7 @@
   {
     "term": "light",
     "context": "light",
-    "reference": "Modals/SettingsContent.qml:628",
+    "reference": "Modals/SettingsContent.qml:639",
     "comment": "current scheme name in theme mode description"
   },
   {
@@ -2426,13 +2438,13 @@
   {
     "term": "read-only",
     "context": "read-only",
-    "reference": "Modals/SettingsContent.qml:943",
+    "reference": "Modals/SettingsContent.qml:954",
     "comment": "read-only suffix in calendar list"
   },
   {
     "term": "synced as \"%1\"",
     "context": "synced as \"%1\"",
-    "reference": "Modals/SettingsContent.qml:941",
+    "reference": "Modals/SettingsContent.qml:952",
     "comment": "renamed calendar provider name suffix in calendar list"
   },
   {

--- a/quickshell/translations/template.json
+++ b/quickshell/translations/template.json
@@ -1169,6 +1169,13 @@
     "comment": ""
   },
   {
+    "term": "Expand day cells to fit every event instead of collapsing extras into \"+N more\".",
+    "translation": "",
+    "context": "show all month events setting description",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "F1/I: Toggle • F10: Help",
     "translation": "",
     "context": "file browser info panel keyboard shortcut hint",
@@ -2229,6 +2236,13 @@
     "term": "Show",
     "translation": "",
     "context": "calendar context menu action to show a hidden calendar",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Show all events in month view",
+    "translation": "",
+    "context": "show all month events setting label",
     "reference": "",
     "comment": ""
   },


### PR DESCRIPTION
This pull request introduces a new setting to the calendar app that allows users to choose whether all events are shown in the month view or if extra events are collapsed into a "+N more" indicator. It also updates the UI and logic in the month view to support this option, and adds the necessary settings infrastructure. Additionally, there are various translation reference updates to keep line numbers and references in sync.

## Before
<img width="634" height="313" alt="image" src="https://github.com/user-attachments/assets/7db409db-6045-45ea-9d28-0856fba0a2a5" />

## After
<img width="840" height="297" alt="image" src="https://github.com/user-attachments/assets/73741f1e-c411-4d53-9a43-1bc303d6b74a" />

## Settings
<img width="1320" height="1080" alt="image" src="https://github.com/user-attachments/assets/08e592b8-4f9e-444b-b091-d8a879de0954" />
