### PR TITLE
feat(ipc): add ui.newEvent to open the new-event editor

### DIFF
--- a/core/internal/ipc/registry.go
+++ b/core/internal/ipc/registry.go
@@ -73,6 +73,7 @@ var Methods = []MethodSpec{
 	{Name: "ui.show", Group: "ui", Desc: "Show the calendar window", Params: []ParamSpec{opt("view", "month|week|day|agenda")}},
 	{Name: "ui.open", Group: "ui", Desc: "Open a webcal/ICS subscription link in the UI", Params: []ParamSpec{req("url", "webcal:// or https ICS URL")}},
 	{Name: "ui.openEvent", Group: "ui", Desc: "Open a specific event's details window", Params: []ParamSpec{req("uid", "event iCal UID"), opt("start", "occurrence start RFC3339 for recurring events")}},
+	{Name: "ui.newEvent", Group: "ui", Desc: "Open the new-event editor", Params: []ParamSpec{opt("start", "prefill start RFC3339 (defaults to the next full hour)")}},
 	{Name: "ui.hide", Group: "ui", Desc: "Hide the calendar window"},
 	{Name: "ui.toggle", Group: "ui", Desc: "Toggle the calendar window", Params: []ParamSpec{opt("view", "month|week|day|agenda")}},
 	{Name: "ui.quit", Group: "ui", Desc: "Quit the running daemon"},

--- a/core/internal/ipc/ui.go
+++ b/core/internal/ipc/ui.go
@@ -66,6 +66,13 @@ func HandleUI(_ context.Context, w *ConnWriter, req Request, deps Deps) {
 		}
 		publishUI(deps, payload)
 		Respond(w, req.ID, map[string]any{"ok": true})
+	case "ui.newEvent":
+		payload := map[string]any{"action": "newEvent"}
+		if start := strings.TrimSpace(ParamString(req.Params, "start")); start != "" {
+			payload["start"] = start
+		}
+		publishUI(deps, payload)
+		Respond(w, req.ID, map[string]any{"ok": true})
 	case "ui.quit":
 		Respond(w, req.ID, map[string]any{"ok": true})
 		go func() {

--- a/core/internal/ipc/ui_test.go
+++ b/core/internal/ipc/ui_test.go
@@ -70,3 +70,17 @@ func TestUIOpenEventPublishesToSubscriber(t *testing.T) {
 	assert.Equal(t, map[string]any{"action": "openEvent", "uid": "evt-2"}, env["data"])
 	assert.Nil(t, deps.Pending.Take())
 }
+
+func TestUINewEventStashesWithoutSubscriber(t *testing.T) {
+	deps := Deps{Bus: NewEventBus(), Pending: &PendingOpen{}}
+	out := routeAndRead(t, Request{ID: 3, Method: "ui.newEvent", Params: map[string]any{"start": "2026-07-01T09:00:00Z"}}, deps)
+
+	result, ok := out["result"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, result["ok"])
+
+	payload := deps.Pending.Take()
+	require.NotNil(t, payload)
+	assert.Equal(t, "newEvent", payload["action"])
+	assert.Equal(t, "2026-07-01T09:00:00Z", payload["start"])
+}

--- a/quickshell/Services/DankCalService.qml
+++ b/quickshell/Services/DankCalService.qml
@@ -58,6 +58,7 @@ Singleton {
     signal windowActionRequested(string action, string view)
     signal subscribeRequested(string url)
     signal openEventRequested(string uid, string start)
+    signal newEventRequested(string start)
     signal colorSchemeUpdate(var data)
 
     onFocusDateChanged: _ensureWindow()
@@ -229,6 +230,9 @@ Singleton {
                     break;
                 case "openEvent":
                     openEventRequested(data.uid || "", data.start || "");
+                    break;
+                case "newEvent":
+                    newEventRequested(data.start || "");
                     break;
                 default:
                     windowActionRequested(data.action || "", data.view || "");

--- a/quickshell/shell.qml
+++ b/quickshell/shell.qml
@@ -46,6 +46,7 @@ ShellRoot {
     property string pendingSubscribeUrl: ""
     property string pendingView: ""
     property var pendingEvent: null
+    property var pendingNewEvent: null
 
     function handleWindowAction(action, view) {
         view = view || "";
@@ -107,6 +108,29 @@ ShellRoot {
         pendingEvent = null;
     }
 
+    function handleNewEvent(start) {
+        pendingNewEvent = {
+            "start": start || ""
+        };
+        showAndFocus();
+        applyPendingNewEvent();
+    }
+
+    function applyPendingNewEvent() {
+        if (!windowLoader.item || !pendingNewEvent)
+            return;
+        const start = pendingNewEvent.start;
+        pendingNewEvent = null;
+        if (start !== "") {
+            const d = new Date(start);
+            if (!isNaN(d.getTime())) {
+                windowLoader.item.openCreateEvent(d);
+                return;
+            }
+        }
+        windowLoader.item.openCreateEvent();
+    }
+
     Connections {
         target: DankCalService
         function onWindowActionRequested(action, view) {
@@ -118,6 +142,9 @@ ShellRoot {
         function onOpenEventRequested(uid, start) {
             root.handleOpenEvent(uid, start);
         }
+        function onNewEventRequested(start) {
+            root.handleNewEvent(start);
+        }
     }
 
     Connections {
@@ -126,6 +153,7 @@ ShellRoot {
             root.applyPendingView();
             root.applyPendingSubscribe();
             root.applyPendingEvent();
+            root.applyPendingNewEvent();
         }
     }
 


### PR DESCRIPTION
dcal exposes `ui.show`/`ui.toggle`/`ui.openEvent` over IPC, but there is no way for external callers (bar widgets, scripts, keybinds) to land directly in the event editor — the closest they can get is day view.

This adds `ui.newEvent` (optional `start` RFC3339 prefill) which opens the New event modal via the existing `openCreateEvent()` path, stashing the action for cold starts exactly like `ui.openEvent` does.

- Go: registry entry + handler in `internal/ipc/ui.go` + test mirroring the openEvent stash test
- QML: `newEventRequested` signal in DankCalService, pending/apply wiring in shell.qml (including the cold-start `onItemChanged` path)

Motivation: the [dms-dankcalendar](https://github.com/arqueon/dms-dankcalendar) DMS bar plugin grew a **+** button; with this IPC it opens the editor directly (it falls back to day view on older daemons).

Tested on niri: `dcal ipc ui.newEvent` opens the editor with the window previously hidden (cold start) and while visible; `go test ./internal/ipc/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)