### PR TITLE
fix: avoid reserved QML identifier in date dialog

### DIFF
--- a/quickshell/Modals/GoToDateDialog.qml
+++ b/quickshell/Modals/GoToDateDialog.qml
@@ -52,9 +52,9 @@ Popup {
         if (/^\d{4}$/.test(s))
             return validDate(parseInt(s, 10), 0, 1);
 
-        const native = new Date(s);
-        if (!isNaN(native.getTime()))
-            return validDate(native.getFullYear(), native.getMonth(), native.getDate());
+        const parsedDate = new Date(s);
+        if (!isNaN(parsedDate.getTime()))
+            return validDate(parsedDate.getFullYear(), parsedDate.getMonth(), parsedDate.getDate());
 
         return null;
     }


### PR DESCRIPTION
## Summary

- rename the `native` local in `GoToDateDialog.parseDate`
- avoid the QML lexer treating the variable as a reserved keyword
- restore loading of the bundled UI

Fixes #59

## Testing

- `make test`
- `prek run --all-files --config .pre-commit-config.yaml`
- headless Quickshell load with `QT_QPA_PLATFORM=offscreen` (reaches `Configuration Loaded`)

No screenshot is included because this fixes configuration parsing and has no visual change.