### PR TITLE
feat: desktop notification when an account needs reauth

### DIFF
--- a/core/cmd/dcal/daemon.go
+++ b/core/cmd/dcal/daemon.go
@@ -152,6 +152,9 @@ func bootDaemonServices(ctx context.Context) (*daemonServices, error) {
 		log.Warnf("desktop notifications unavailable: %v", err)
 		notifier = nil
 	}
+	if notifier != nil {
+		syncEngine.SetSender(notifier)
+	}
 	var sender reminders.Sender
 	if notifier != nil {
 		sender = notifier

--- a/core/internal/sync/engine.go
+++ b/core/internal/sync/engine.go
@@ -12,12 +12,20 @@ import (
 	entaccount "github.com/AvengeMedia/dankcalendar/core/ent/account"
 	"github.com/AvengeMedia/dankcalendar/core/internal/calendar"
 	"github.com/AvengeMedia/dankcalendar/core/internal/eventconv"
+	"github.com/AvengeMedia/dankcalendar/core/internal/notify"
 	"github.com/AvengeMedia/dankcalendar/core/internal/taskconv"
 	"github.com/AvengeMedia/dankcalendar/core/repo"
 	"github.com/AvengeMedia/dankgo/log"
 )
 
 type Notifier func(topic string, data any)
+
+// Sender delivers a desktop popup when an account newly requires
+// reauthentication, since the IPC "accounts" event alone only reaches the
+// Settings UI when it happens to be open.
+type Sender interface {
+	Send(n notify.Notification) (uint32, error)
+}
 
 const (
 	// minInterval floors how often an account may be re-synced so a provider
@@ -35,6 +43,7 @@ type Engine struct {
 	interval   time.Duration
 	intervalFn func() time.Duration
 	notify     Notifier
+	sender     Sender
 	now        func() time.Time
 
 	wake chan struct{}
@@ -62,6 +71,10 @@ func NewEngine(r *repo.Repo, registry *calendar.Registry, secrets calendar.Secre
 }
 
 func (e *Engine) SetNotifier(n Notifier) { e.notify = n }
+
+// SetSender wires a desktop notifier used to alert the user when an account
+// needs reauthentication. Optional: a nil sender leaves that popup silent.
+func (e *Engine) SetSender(s Sender) { e.sender = s }
 
 func (e *Engine) publish(topic string, data any) {
 	if e.notify == nil {
@@ -355,6 +368,16 @@ func (e *Engine) recordAuthState(ctx context.Context, acc *ent.Account, syncErr 
 	acc.NeedsReauth = needsReauth
 	acc.AuthError = authError
 	e.publish("accounts", map[string]any{"type": "changed", "accountId": acc.ID})
+
+	if needsReauth && e.sender != nil {
+		if _, err := e.sender.Send(notify.Notification{
+			Summary: "Dank Calendar",
+			Body:    fmt.Sprintf("%s needs to sign in again to keep syncing.", acc.DisplayName),
+			Urgency: notify.UrgencyNormal,
+		}); err != nil {
+			log.Warnf("send reauth notification for %s: %v", acc.ID, err)
+		}
+	}
 }
 
 func (e *Engine) syncCalendar(ctx context.Context, provider calendar.Provider, cal calendar.Calendar, token string) (time.Duration, error) {

--- a/core/internal/sync/engine_test.go
+++ b/core/internal/sync/engine_test.go
@@ -15,9 +15,20 @@ import (
 	"github.com/AvengeMedia/dankcalendar/core/ent/event"
 	"github.com/AvengeMedia/dankcalendar/core/internal/calendar"
 	"github.com/AvengeMedia/dankcalendar/core/internal/mocks"
+	"github.com/AvengeMedia/dankcalendar/core/internal/notify"
 	enginesync "github.com/AvengeMedia/dankcalendar/core/internal/sync"
 	"github.com/AvengeMedia/dankcalendar/core/repo"
 )
+
+// fakeSender records notifications instead of touching D-Bus.
+type fakeSender struct {
+	sent []notify.Notification
+}
+
+func (f *fakeSender) Send(n notify.Notification) (uint32, error) {
+	f.sent = append(f.sent, n)
+	return uint32(len(f.sent)), nil
+}
 
 type EngineSuite struct {
 	suite.Suite
@@ -406,6 +417,49 @@ func (s *EngineSuite) TestSyncAccountLeavesReauthClearOnGenericError() {
 	acc, err := s.repo.GetAccount(s.ctx, s.account.ID)
 	s.Require().NoError(err)
 	s.False(acc.NeedsReauth)
+}
+
+func (s *EngineSuite) TestSyncAccountNotifiesOnReauthTransition() {
+	sender := &fakeSender{}
+	s.engine.SetSender(sender)
+
+	provider := s.registerProvider()
+	authErr := fmt.Errorf("list google calendars: %w", calendar.ErrReauthRequired)
+	provider.EXPECT().ListCalendars(mock.Anything).Return(nil, authErr)
+	provider.EXPECT().Close().Return(nil)
+
+	s.Require().Error(s.engine.SyncAccount(s.ctx, s.account))
+	s.Require().Len(sender.sent, 1)
+	s.Contains(sender.sent[0].Body, s.account.DisplayName)
+}
+
+func (s *EngineSuite) TestSyncAccountDoesNotRenotifyOnRepeatedReauthFailure() {
+	sender := &fakeSender{}
+	s.engine.SetSender(sender)
+
+	provider := s.registerProvider()
+	authErr := fmt.Errorf("list google calendars: %w", calendar.ErrReauthRequired)
+	provider.EXPECT().ListCalendars(mock.Anything).Return(nil, authErr).Twice()
+	provider.EXPECT().Close().Return(nil).Twice()
+
+	acc, err := s.repo.GetAccount(s.ctx, s.account.ID)
+	s.Require().NoError(err)
+
+	s.Require().Error(s.engine.SyncAccount(s.ctx, acc))
+	s.Require().Error(s.engine.SyncAccount(s.ctx, acc))
+	s.Require().Len(sender.sent, 1)
+}
+
+func (s *EngineSuite) TestSyncAccountDoesNotNotifyOnGenericError() {
+	sender := &fakeSender{}
+	s.engine.SetSender(sender)
+
+	provider := s.registerProvider()
+	provider.EXPECT().ListCalendars(mock.Anything).Return(nil, errors.New("upstream down"))
+	provider.EXPECT().Close().Return(nil)
+
+	s.Require().Error(s.engine.SyncAccount(s.ctx, s.account))
+	s.Empty(sender.sent)
 }
 
 func (s *EngineSuite) TestSyncAccountClearsReauthOnSuccess() {


### PR DESCRIPTION
## Summary
- `Engine` gains an optional `Sender` (wired to the desktop notifier in
  `bootDaemonServices`); on the false→true transition of an account's
  `needs_reauth` flag, it fires a popup: "<account> needs to sign in
  again to keep syncing."
- Notification fires once per transition, not on every failed sync
  cycle, and never fires for generic (non-auth) sync errors.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/sync/...`
- [x] New tests: notifies on reauth transition, does not re-notify on
      repeated reauth failure, does not notify on generic errors