### PR TITLE
fix: keepassxc prompt hangs by migrating to zalando/go-keyring

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -4,21 +4,23 @@ go 1.26.4
 
 require (
 	entgo.io/ent v0.14.6
-	github.com/99designs/keyring v1.2.2
 	github.com/AvengeMedia/dankgo v0.0.0-20260723140649-8720f7c4d074
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2
 	github.com/adrg/xdg v0.5.3
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/danielgtaylor/huma/v2 v2.38.0
+	github.com/dvsekhvalnov/jose2go v1.8.0
 	github.com/emersion/go-ical v0.0.0-20250609112844-439c63cef608
 	github.com/emersion/go-webdav v0.7.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/uuid v1.6.0
+	github.com/mtibben/percent v0.2.1
 	github.com/pressly/goose/v3 v3.27.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/teambition/rrule-go v1.8.2
+	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.44.0
 	google.golang.org/api v0.287.0
@@ -30,7 +32,6 @@ require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/JohannesKaufmann/dom v0.3.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
@@ -45,22 +46,18 @@ require (
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/dvsekhvalnov/jose2go v1.8.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/inflect v0.21.6 // indirect
-	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.18 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/schema v1.4.1 // indirect
-	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
@@ -68,7 +65,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/core/go.sum
+++ b/core/go.sum
@@ -8,10 +8,6 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 entgo.io/ent v0.14.6 h1:/f2696BpwuWAEEG6PVGWflg6+Inrpq4pRWuNlWz/Skk=
 entgo.io/ent v0.14.6/go.mod h1:z46QBUdGC+BATwsedbDuREfSS0oSCV+csdEYlL4p73s=
-github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
-github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
-github.com/99designs/keyring v1.2.2 h1:pZd3neh/EmUzWONb35LxQfvuY7kiSXAq3HQd97+XBn0=
-github.com/99designs/keyring v1.2.2/go.mod h1:wes/FrByc8j7lFOAGLGSNEg8f/PaI3cgTBqhFkHUrPk=
 github.com/AvengeMedia/dankgo v0.0.0-20260723140649-8720f7c4d074 h1:KoPNgo7AGjq9KLB4VEY4Kt/PXTk5U0BafVQ3UpwVEjI=
 github.com/AvengeMedia/dankgo v0.0.0-20260723140649-8720f7c4d074/go.mod h1:7p7cfydr4WM1G6eOPFlANXF3IV5du3FoA4CbDPprHAo=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
@@ -53,8 +49,6 @@ github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJ
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/danielgtaylor/huma/v2 v2.38.0 h1:fb0WZCatnaiHLphMQDDWDjygNxfMkX/ENma3QsRl7vY=
 github.com/danielgtaylor/huma/v2 v2.38.0/go.mod h1:k9hwjlgWFt1t2jsmQGlsgXAG2FBTZa4kkjV581qAtfo=
-github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
-github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -84,8 +78,6 @@ github.com/go-openapi/inflect v0.21.6 h1:0Se5BlyDT4hnV9JQQKA63W9TIUU6SC4hPJiY3qJ
 github.com/go-openapi/inflect v0.21.6/go.mod h1:ksYcnLD7j24H79hdqOMmWaLXjFXd0LTkRoBA0UazLW8=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
-github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -104,8 +96,6 @@ github.com/googleapis/gax-go/v2 v2.22.0 h1:PjIWBpgGIVKGoCXuiCoP64altEJCj3/Ei+kSU
 github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeFuiOzI4Rqw5+aY=
 github.com/gorilla/schema v1.4.1 h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E=
 github.com/gorilla/schema v1.4.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
-github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
-github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
@@ -171,6 +161,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zclconf/go-cty v1.18.1 h1:yEGE8M4iIZlyKQURZNb2SnEyZlZHUcBCnx6KF81KuwM=
 github.com/zclconf/go-cty v1.18.1/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/core/internal/keyring/file_store.go
+++ b/core/internal/keyring/file_store.go
@@ -1,0 +1,159 @@
+package keyring
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	jose "github.com/dvsekhvalnov/jose2go"
+	"github.com/mtibben/percent"
+)
+
+type passwordFunc func(prompt string) (string, error)
+
+type fileStore struct {
+	dir          string
+	passwordFunc passwordFunc
+	password     string
+}
+
+type legacyStoredSecret struct {
+	Key         string
+	Data        []byte
+	Label       string
+	Description string
+}
+
+func openFileStore(passwordFn passwordFunc) (*fileStore, error) {
+	dir, err := keyringDir()
+	if err != nil {
+		return nil, err
+	}
+
+	store := &fileStore{dir: dir, passwordFunc: passwordFn}
+	if err := store.unlock(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *fileStore) Get(key string) ([]byte, error) {
+	filename, err := s.filename(key)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := os.ReadFile(filename)
+	switch {
+	case os.IsNotExist(err):
+		return nil, ErrNotFound
+	case err != nil:
+		return nil, err
+	}
+
+	if err := s.unlock(); err != nil {
+		return nil, err
+	}
+
+	payload, _, err := jose.Decode(string(bytes), s.password)
+	if err != nil {
+		return nil, err
+	}
+	return decodeStoredSecret(key, []byte(payload)), nil
+}
+
+func (s *fileStore) Set(key string, value []byte, label string) error {
+	payload, err := encodeStoredSecret(key, value, label)
+	if err != nil {
+		return err
+	}
+
+	if err := s.unlock(); err != nil {
+		return err
+	}
+
+	token, err := jose.Encrypt(string(payload), jose.PBES2_HS256_A128KW, jose.A256GCM, s.password,
+		jose.Headers(map[string]any{
+			"created": time.Now().String(),
+		}))
+	if err != nil {
+		return err
+	}
+
+	filename, err := s.filename(key)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filename, []byte(token), 0o600)
+}
+
+func (s *fileStore) Delete(key string) error {
+	filename, err := s.filename(key)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(filename); os.IsNotExist(err) {
+		return ErrNotFound
+	} else {
+		return err
+	}
+}
+
+func (s *fileStore) resolveDir() (string, error) {
+	if s.dir == "" {
+		return "", fmt.Errorf("no directory provided for file keyring")
+	}
+
+	stat, err := os.Stat(s.dir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(s.dir, 0o700)
+	} else if err != nil && stat != nil && !stat.IsDir() {
+		err = fmt.Errorf("%s is a file, not a directory", s.dir)
+	}
+
+	return s.dir, err
+}
+
+func (s *fileStore) unlock() error {
+	if _, err := s.resolveDir(); err != nil {
+		return err
+	}
+
+	if s.password != "" {
+		return nil
+	}
+
+	pwd, err := s.passwordFunc(fmt.Sprintf("Enter passphrase to unlock %q", s.dir))
+	if err != nil {
+		return err
+	}
+	s.password = pwd
+	return nil
+}
+
+func (s *fileStore) filename(key string) (string, error) {
+	dir, err := s.resolveDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, percent.Encode(key, "/")), nil
+}
+
+func encodeStoredSecret(key string, value []byte, label string) ([]byte, error) {
+	return json.Marshal(legacyStoredSecret{
+		Key:         key,
+		Data:        value,
+		Label:       label,
+		Description: credentialDescription,
+	})
+}
+
+func decodeStoredSecret(key string, payload []byte) []byte {
+	var legacy legacyStoredSecret
+	if err := json.Unmarshal(payload, &legacy); err == nil && legacy.Key == key {
+		return legacy.Data
+	}
+	return payload
+}

--- a/core/internal/keyring/keyring.go
+++ b/core/internal/keyring/keyring.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	kr "github.com/99designs/keyring"
 	"github.com/godbus/dbus/v5"
 
 	"github.com/AvengeMedia/dankcalendar/core/internal/paths"
@@ -19,90 +18,83 @@ import (
 )
 
 const (
-	serviceName            = "dankcal"
-	keychainName           = "dankcal"
-	fallbackCollectionName = "login"
-
-	secretServiceBus  = "org.freedesktop.secrets"
-	secretServicePath = "/org/freedesktop/secrets"
+	serviceName                = "dankcal"
+	fallbackCollectionName     = "login"
+	credentialDescription      = "Dank Calendar credential"
+	secretServiceBus           = "org.freedesktop.secrets"
+	secretServicePath          = "/org/freedesktop/secrets"
+	secretServiceInterface     = "org.freedesktop.Secret.Service"
+	secretServiceCollectionIfc = "org.freedesktop.Secret.Collection"
+	secretServiceItemIfc       = "org.freedesktop.Secret.Item"
+	secretServicePromptIfc     = "org.freedesktop.Secret.Prompt"
+	secretServicePromptTimeout = 30 * time.Second
 )
 
 var ErrNotFound = errors.New("keyring: key not found")
 
 type Store struct {
-	ring      kr.Keyring
+	secret    *secretServiceStore
+	file      *fileStore
 	available bool
 }
 
 func Open() *Store {
-	cfg := defaultConfig()
 	if portal.InFlatpak() {
 		if _, err := portalSecret(); err != nil {
 			log.Warnf("secret portal unavailable, falling back to encrypted db (%v)", err)
 			return &Store{available: false}
 		}
-		cfg = flatpakConfig()
+
+		store, err := openFileStore(portalFilePassword)
+		if err != nil {
+			log.Warnf("keyring unavailable, falling back to encrypted db (%v)", err)
+			return &Store{available: false}
+		}
+
+		log.Debugf("keyring backend ready")
+		return &Store{file: store, available: true}
 	}
 
-	ring, err := kr.Open(cfg)
-	if err != nil {
-		log.Warnf("keyring unavailable, falling back to encrypted db (%v)", err)
-		return &Store{available: false}
+	secret, secretErr := openSecretServiceStore(resolveDefaultCollectionPath())
+	if secretErr == nil {
+		log.Debugf("keyring backend ready")
+		return &Store{secret: secret, available: true}
 	}
 
-	if _, probeErr := ring.Get("__dankcal_probe__"); probeErr != nil && !errors.Is(probeErr, kr.ErrKeyNotFound) {
-		log.Warnf("keyring probe failed, falling back to encrypted db (%v)", probeErr)
-		return &Store{available: false}
+	store, fileErr := openFileStore(filePassword)
+	if fileErr == nil {
+		log.Warnf("system keyring unavailable, using encrypted local keyring (%v)", secretErr)
+		log.Debugf("keyring backend ready")
+		return &Store{file: store, available: true}
 	}
 
-	log.Debugf("keyring backend ready")
-	return &Store{ring: ring, available: true}
+	log.Warnf("keyring unavailable, falling back to encrypted db (%v)", errors.Join(secretErr, fileErr))
+	return &Store{available: false}
 }
 
-func defaultConfig() kr.Config {
-	fileDir := ""
-	if dir, err := paths.DataDir(); err == nil {
-		fileDir = filepath.Join(dir, "keyring")
-	}
-
-	return kr.Config{
-		ServiceName:             serviceName,
-		KeychainName:            keychainName,
-		LibSecretCollectionName: resolveDefaultCollection(),
-		KWalletAppID:            serviceName,
-		KWalletFolder:           serviceName,
-		FileDir:                 fileDir,
-		FilePasswordFunc:        filePassword,
-		AllowedBackends: []kr.BackendType{
-			kr.SecretServiceBackend,
-			kr.KWalletBackend,
-			kr.PassBackend,
-			kr.FileBackend,
-		},
-	}
-}
-
-// resolveDefaultCollection reuses the Secret Service "default" collection
-// (e.g. KWallet's existing wallet) instead of forcing a separate "login" one.
-func resolveDefaultCollection() string {
+func resolveDefaultCollectionPath() dbus.ObjectPath {
 	conn, err := dbus.SessionBus()
 	if err != nil {
-		return fallbackCollectionName
+		return fallbackCollectionPath()
 	}
 
 	var path dbus.ObjectPath
 	obj := conn.Object(secretServiceBus, dbus.ObjectPath(secretServicePath))
-	if err := obj.Call("org.freedesktop.Secret.Service.ReadAlias", 0, "default").Store(&path); err != nil {
-		return fallbackCollectionName
+	if err := obj.Call(secretServiceInterface+".ReadAlias", 0, "default").Store(&path); err != nil {
+		return fallbackCollectionPath()
+	}
+	if path == "" || path == "/" {
+		return fallbackCollectionPath()
 	}
 
-	name := collectionBaseName(string(path))
-	if name == "" {
-		return fallbackCollectionName
+	if name := collectionBaseName(string(path)); name != "" {
+		log.Debugf("keyring using default secret collection %q", name)
 	}
+	return path
+}
 
-	log.Debugf("keyring using default secret collection %q", name)
-	return name
+func fallbackCollectionPath() dbus.ObjectPath {
+	return dbus.ObjectPath(secretServicePath + "/collection/" + fallbackCollectionName)
 }
 
 func collectionBaseName(path string) string {
@@ -115,7 +107,7 @@ func collectionBaseName(path string) string {
 }
 
 // decodeCollectionPath expands the "_XX" hex escapes the Secret Service uses in
-// object paths, matching how 99designs/keyring matches collections by name.
+// object paths.
 func decodeCollectionPath(src string) string {
 	var b strings.Builder
 	for i := 0; i < len(src); i++ {
@@ -138,23 +130,6 @@ func decodeCollectionPath(src string) string {
 
 func filePassword(prompt string) (string, error) {
 	return "dankcal-local", nil
-}
-
-// flatpakConfig avoids org.freedesktop.secrets entirely: the sandbox has no
-// talk permission for it, so the encrypted file backend is keyed with the
-// per-app master secret from the XDG Secret portal instead.
-func flatpakConfig() kr.Config {
-	fileDir := ""
-	if dir, err := paths.DataDir(); err == nil {
-		fileDir = filepath.Join(dir, "keyring")
-	}
-
-	return kr.Config{
-		ServiceName:      serviceName,
-		FileDir:          fileDir,
-		FilePasswordFunc: portalFilePassword,
-		AllowedBackends:  []kr.BackendType{kr.FileBackend},
-	}
 }
 
 var portalSecret = sync.OnceValues(func() (string, error) {
@@ -183,6 +158,10 @@ func entryKey(accountID, key string) string {
 	return accountID + "::" + key
 }
 
+func entryLabel(accountID, key string) string {
+	return "dankcal: " + accountID + " (" + key + ")"
+}
+
 func (s *Store) Available() bool { return s.available }
 
 func (s *Store) Get(accountID, key string) ([]byte, error) {
@@ -190,14 +169,12 @@ func (s *Store) Get(accountID, key string) ([]byte, error) {
 		return nil, ErrNotFound
 	}
 
-	item, err := s.ring.Get(entryKey(accountID, key))
-	switch {
-	case errors.Is(err, kr.ErrKeyNotFound):
-		return nil, ErrNotFound
-	case err != nil:
+	entry := entryKey(accountID, key)
+	value, err := s.backendGet(entry)
+	if err != nil {
 		return nil, fmt.Errorf("keyring get: %w", err)
 	}
-	return item.Data, nil
+	return value, nil
 }
 
 func (s *Store) Set(accountID, key string, value []byte) error {
@@ -205,13 +182,7 @@ func (s *Store) Set(accountID, key string, value []byte) error {
 		return ErrNotFound
 	}
 
-	err := s.ring.Set(kr.Item{
-		Key:         entryKey(accountID, key),
-		Data:        value,
-		Label:       "dankcal: " + accountID + " (" + key + ")",
-		Description: "Dank Calendar credential",
-	})
-	if err != nil {
+	if err := s.backendSet(entryKey(accountID, key), value, entryLabel(accountID, key)); err != nil {
 		return fmt.Errorf("keyring set: %w", err)
 	}
 	return nil
@@ -222,12 +193,53 @@ func (s *Store) Delete(accountID, key string) error {
 		return nil
 	}
 
-	err := s.ring.Remove(entryKey(accountID, key))
+	err := s.backendDelete(entryKey(accountID, key))
 	switch {
-	case errors.Is(err, kr.ErrKeyNotFound):
+	case errors.Is(err, ErrNotFound):
 		return nil
 	case err != nil:
 		return fmt.Errorf("keyring delete: %w", err)
 	}
 	return nil
+}
+
+func (s *Store) backendGet(key string) ([]byte, error) {
+	switch {
+	case s.secret != nil:
+		return s.secret.Get(key)
+	case s.file != nil:
+		return s.file.Get(key)
+	default:
+		return nil, ErrNotFound
+	}
+}
+
+func (s *Store) backendSet(key string, value []byte, label string) error {
+	switch {
+	case s.secret != nil:
+		return s.secret.Set(key, value, label)
+	case s.file != nil:
+		return s.file.Set(key, value, label)
+	default:
+		return ErrNotFound
+	}
+}
+
+func (s *Store) backendDelete(key string) error {
+	switch {
+	case s.secret != nil:
+		return s.secret.Delete(key)
+	case s.file != nil:
+		return s.file.Delete(key)
+	default:
+		return ErrNotFound
+	}
+}
+
+func keyringDir() (string, error) {
+	dir, err := paths.DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "keyring"), nil
 }

--- a/core/internal/keyring/keyring_test.go
+++ b/core/internal/keyring/keyring_test.go
@@ -24,3 +24,20 @@ func TestCollectionBaseName(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeStoredSecret(t *testing.T) {
+	payload, err := encodeStoredSecret("acc::token", []byte("sekret"), "label")
+	if err != nil {
+		t.Fatalf("encodeStoredSecret() error = %v", err)
+	}
+
+	if got := string(decodeStoredSecret("acc::token", payload)); got != "sekret" {
+		t.Fatalf("decodeStoredSecret() = %q, want %q", got, "sekret")
+	}
+}
+
+func TestDecodeStoredSecretRawPayload(t *testing.T) {
+	if got := string(decodeStoredSecret("acc::token", []byte("raw-secret"))); got != "raw-secret" {
+		t.Fatalf("decodeStoredSecret(raw) = %q, want %q", got, "raw-secret")
+	}
+}

--- a/core/internal/keyring/migrate.go
+++ b/core/internal/keyring/migrate.go
@@ -1,13 +1,6 @@
 package keyring
 
-import (
-	"errors"
-	"fmt"
-
-	kr "github.com/99designs/keyring"
-)
-
-const legacyLoginCollection = "login"
+import "fmt"
 
 type SecretRef struct {
 	AccountID string
@@ -18,38 +11,12 @@ type SecretRef struct {
 // Secret Service collection into the resolved default one. It is a no-op when
 // login is already the default, no refs are given, or an entry isn't present.
 func (s *Store) MigrateLoginCollection(refs []SecretRef) (int, error) {
-	if !s.available || len(refs) == 0 {
+	if !s.available || s.secret == nil || len(refs) == 0 {
 		return 0, nil
 	}
-	if resolveDefaultCollection() == legacyLoginCollection {
-		return 0, nil
-	}
-
-	login, err := kr.Open(kr.Config{
-		ServiceName:             serviceName,
-		LibSecretCollectionName: legacyLoginCollection,
-		AllowedBackends:         []kr.BackendType{kr.SecretServiceBackend},
-	})
+	migrated, err := s.secret.MigrateLoginCollection(refs)
 	if err != nil {
-		return 0, fmt.Errorf("open legacy login collection: %w", err)
-	}
-
-	migrated := 0
-	for _, ref := range refs {
-		ek := entryKey(ref.AccountID, ref.Key)
-		item, err := login.Get(ek)
-		switch {
-		case errors.Is(err, kr.ErrKeyNotFound):
-			continue
-		case err != nil:
-			return migrated, fmt.Errorf("read %s from login: %w", ek, err)
-		}
-
-		if err := s.Set(ref.AccountID, ref.Key, item.Data); err != nil {
-			return migrated, err
-		}
-		_ = login.Remove(ek)
-		migrated++
+		return migrated, fmt.Errorf("migrate login collection: %w", err)
 	}
 	return migrated, nil
 }

--- a/core/internal/keyring/secretservice.go
+++ b/core/internal/keyring/secretservice.go
@@ -1,0 +1,300 @@
+package keyring
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+	ss "github.com/zalando/go-keyring/secret_service"
+)
+
+type secretServiceStore struct {
+	svc            *ss.SecretService
+	collectionPath dbus.ObjectPath
+}
+
+func openSecretServiceStore(collectionPath dbus.ObjectPath) (*secretServiceStore, error) {
+	svc, err := ss.NewSecretService()
+	if err != nil {
+		return nil, err
+	}
+	if err := svc.CheckCollectionPath(collectionPath); err != nil {
+		return nil, fmt.Errorf("check secret collection %q: %w", collectionBaseName(string(collectionPath)), err)
+	}
+	return &secretServiceStore{svc: svc, collectionPath: collectionPath}, nil
+}
+
+func (s *secretServiceStore) Get(key string) ([]byte, error) {
+	return s.getFromCollection(s.collectionPath, key)
+}
+
+func (s *secretServiceStore) Set(key string, value []byte, label string) error {
+	if err := s.unlock(s.collectionPath); err != nil {
+		return err
+	}
+
+	session, err := s.svc.OpenSession()
+	if err != nil {
+		return err
+	}
+	defer s.svc.Close(session)
+
+	secret := ss.Secret{
+		Session:     session.Path(),
+		Parameters:  []byte{},
+		Value:       value,
+		ContentType: "application/octet-stream",
+	}
+	properties := map[string]dbus.Variant{
+		secretServiceItemIfc + ".Label": dbus.MakeVariant(label),
+		secretServiceItemIfc + ".Attributes": dbus.MakeVariant(map[string]string{
+			"service":  serviceName,
+			"username": key,
+		}),
+	}
+
+	var itemPath, prompt dbus.ObjectPath
+	err = s.collection().Call(secretServiceCollectionIfc+".CreateItem", 0, properties, secret, true).Store(&itemPath, &prompt)
+	if err != nil {
+		return err
+	}
+
+	dismissed, _, err := s.handlePrompt(prompt)
+	if err != nil {
+		return err
+	}
+	if dismissed {
+		return errors.New("secret service prompt was dismissed")
+	}
+	return nil
+}
+
+func (s *secretServiceStore) Delete(key string) error {
+	return s.deleteFromCollection(s.collectionPath, key)
+}
+
+func (s *secretServiceStore) MigrateLoginCollection(refs []SecretRef) (int, error) {
+	loginPath := fallbackCollectionPath()
+	if s.collectionPath == loginPath || len(refs) == 0 {
+		return 0, nil
+	}
+	if err := s.svc.CheckCollectionPath(loginPath); err != nil {
+		return 0, nil
+	}
+
+	migrated := 0
+	for _, ref := range refs {
+		key := entryKey(ref.AccountID, ref.Key)
+		value, err := s.getFromCollection(loginPath, key)
+		switch {
+		case errors.Is(err, ErrNotFound):
+			continue
+		case err != nil:
+			return migrated, fmt.Errorf("read %s from login: %w", key, err)
+		}
+
+		if err := s.Set(key, value, entryLabel(ref.AccountID, ref.Key)); err != nil {
+			return migrated, err
+		}
+		_ = s.deleteFromCollection(loginPath, key)
+		migrated++
+	}
+	return migrated, nil
+}
+
+func (s *secretServiceStore) getFromCollection(collectionPath dbus.ObjectPath, key string) ([]byte, error) {
+	if err := s.unlock(collectionPath); err != nil {
+		return nil, err
+	}
+
+	collection := s.collectionAt(collectionPath)
+	itemPath, err := s.findCurrentItem(collection, key)
+	if err == nil {
+		return s.readItemSecret(itemPath, key)
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
+
+	itemPath, err = s.findLegacyItem(collection, key)
+	if err == nil {
+		return s.readItemSecret(itemPath, key)
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
+
+	return nil, ErrNotFound
+}
+
+func (s *secretServiceStore) deleteFromCollection(collectionPath dbus.ObjectPath, key string) error {
+	collection := s.collectionAt(collectionPath)
+	deleted := false
+
+	itemPath, err := s.findCurrentItem(collection, key)
+	switch {
+	case err == nil:
+		if err := s.deleteItem(itemPath); err != nil {
+			return err
+		}
+		deleted = true
+	case !errors.Is(err, ErrNotFound):
+		return err
+	}
+
+	itemPath, err = s.findLegacyItem(collection, key)
+	switch {
+	case err == nil:
+		if err := s.deleteItem(itemPath); err != nil {
+			return err
+		}
+		deleted = true
+	case !errors.Is(err, ErrNotFound):
+		return err
+	}
+
+	if !deleted {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *secretServiceStore) readItemSecret(itemPath dbus.ObjectPath, key string) ([]byte, error) {
+	if err := s.unlock(itemPath); err != nil {
+		return nil, err
+	}
+
+	session, err := s.svc.OpenSession()
+	if err != nil {
+		return nil, err
+	}
+	defer s.svc.Close(session)
+
+	secret, err := s.svc.GetSecret(itemPath, session.Path())
+	if err != nil {
+		return nil, err
+	}
+	return decodeStoredSecret(key, secret.Value), nil
+}
+
+func (s *secretServiceStore) findCurrentItem(collection dbus.BusObject, key string) (dbus.ObjectPath, error) {
+	results, err := s.svc.SearchItems(collection, map[string]string{
+		"service":  serviceName,
+		"username": key,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(results) == 0 {
+		return "", ErrNotFound
+	}
+	return results[0], nil
+}
+
+func (s *secretServiceStore) findLegacyItem(collection dbus.BusObject, key string) (dbus.ObjectPath, error) {
+	results, err := s.svc.SearchItems(collection, map[string]string{"profile": key})
+	if err != nil {
+		return "", err
+	}
+	if len(results) == 0 {
+		return "", ErrNotFound
+	}
+	return results[0], nil
+}
+
+func (s *secretServiceStore) deleteItem(itemPath dbus.ObjectPath) error {
+	if err := s.unlock(itemPath); err != nil {
+		return err
+	}
+
+	var prompt dbus.ObjectPath
+	err := s.svc.Object(secretServiceBus, itemPath).Call(secretServiceItemIfc+".Delete", 0).Store(&prompt)
+	if err != nil {
+		return err
+	}
+
+	dismissed, _, err := s.handlePrompt(prompt)
+	if err != nil {
+		return err
+	}
+	if dismissed {
+		return errors.New("secret service prompt was dismissed")
+	}
+	return nil
+}
+
+func (s *secretServiceStore) unlock(path dbus.ObjectPath) error {
+	var unlocked []dbus.ObjectPath
+	var prompt dbus.ObjectPath
+	err := s.service().Call(secretServiceInterface+".Unlock", 0, []dbus.ObjectPath{path}).Store(&unlocked, &prompt)
+	if err != nil {
+		return err
+	}
+
+	dismissed, _, err := s.handlePrompt(prompt)
+	if err != nil {
+		return err
+	}
+	if dismissed {
+		return errors.New("secret service prompt was dismissed")
+	}
+	return nil
+}
+
+func (s *secretServiceStore) handlePrompt(prompt dbus.ObjectPath) (bool, dbus.Variant, error) {
+	if prompt == "" || prompt == "/" {
+		return false, dbus.MakeVariant(""), nil
+	}
+
+	options := []dbus.MatchOption{
+		dbus.WithMatchObjectPath(prompt),
+		dbus.WithMatchInterface(secretServicePromptIfc),
+	}
+	if err := s.svc.AddMatchSignal(options...); err != nil {
+		return false, dbus.MakeVariant(""), err
+	}
+	// Explicitly discard the error from RemoveMatchSignal to satisfy linters.
+	defer func() { _ = s.svc.RemoveMatchSignal(options...) }()
+
+	ch := make(chan *dbus.Signal, 1)
+	s.svc.Signal(ch)
+	defer s.svc.RemoveSignal(ch)
+
+	if err := s.svc.Object(secretServiceBus, prompt).Call(secretServicePromptIfc+".Prompt", 0, "").Err; err != nil {
+		return false, dbus.MakeVariant(""), err
+	}
+
+	timer := time.NewTimer(secretServicePromptTimeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case signal := <-ch:
+			if signal == nil || signal.Path != prompt || signal.Name != secretServicePromptIfc+".Completed" || len(signal.Body) < 2 {
+				continue
+			}
+
+			dismissed, _ := signal.Body[0].(bool)
+			result, ok := signal.Body[1].(dbus.Variant)
+			if !ok {
+				return false, dbus.MakeVariant(""), errors.New("secret service prompt returned an invalid result")
+			}
+			return dismissed, result, nil
+		case <-timer.C:
+			return false, dbus.MakeVariant(""), fmt.Errorf("secret service prompt timed out after %s", secretServicePromptTimeout)
+		}
+	}
+}
+
+func (s *secretServiceStore) service() dbus.BusObject {
+	return s.svc.Object(secretServiceBus, dbus.ObjectPath(secretServicePath))
+}
+
+func (s *secretServiceStore) collection() dbus.BusObject {
+	return s.collectionAt(s.collectionPath)
+}
+
+func (s *secretServiceStore) collectionAt(path dbus.ObjectPath) dbus.BusObject {
+	return s.svc.Object(secretServiceBus, path)
+}

--- a/distro/flatpak/go.mod.yml
+++ b/distro/flatpak/go.mod.yml
@@ -7,11 +7,6 @@
   strip-components: 2
   type: archive
   url: https://proxy.golang.org/entgo.io/ent/@v/v0.14.6.zip
-- dest: core/vendor/github.com/99designs/keyring
-  sha256: 7204ea1194e7835a02d9f8f3cf1ba30dce143dd9a3353ead71a46ffcd418d7be
-  strip-components: 3
-  type: archive
-  url: https://proxy.golang.org/github.com/99designs/keyring/@v/v1.2.2.zip
 - dest: core/vendor/github.com/AvengeMedia/dankgo
   sha256: b94e2d85f188a372d67ed91a94467cfbbda7d6adc619d3fadb2626d3036b33e9
   strip-components: 3
@@ -37,6 +32,11 @@
   strip-components: 4
   type: archive
   url: https://proxy.golang.org/github.com/danielgtaylor/huma/v2/@v/v2.38.0.zip
+- dest: core/vendor/github.com/dvsekhvalnov/jose2go
+  sha256: 3cfe140e405a123426b17d2a9d56b9f38317822effd738f9509d32932007ee71
+  strip-components: 3
+  type: archive
+  url: https://proxy.golang.org/github.com/dvsekhvalnov/jose2go/@v/v1.8.0.zip
 - dest: core/vendor/github.com/emersion/go-ical
   sha256: 1d7af01ae7588bfffb38b5ec6a0e116df47283347dd996323fa84dea9219e99d
   strip-components: 3
@@ -62,6 +62,11 @@
   strip-components: 3
   type: archive
   url: https://proxy.golang.org/github.com/google/uuid/@v/v1.6.0.zip
+- dest: core/vendor/github.com/mtibben/percent
+  sha256: 21061f4a2b74cb0c65a1c6150e6a1ddbedcd3539a4ef5f0075d1a097f3224ee4
+  strip-components: 3
+  type: archive
+  url: https://proxy.golang.org/github.com/mtibben/percent/@v/v0.2.1.zip
 - dest: core/vendor/github.com/pressly/goose/v3
   sha256: 22b88786af7e06684f3ec5a25fa8e3495d039296dbf5d20c6214fd3150906b08
   strip-components: 4
@@ -82,6 +87,11 @@
   strip-components: 3
   type: archive
   url: https://proxy.golang.org/github.com/teambition/rrule-go/@v/v1.8.2.zip
+- dest: core/vendor/github.com/zalando/go-keyring
+  sha256: af9d1310d6e1eaadb6c975f2f9b1c22c8a2d1ea2497645f5ee62eac26472c97a
+  strip-components: 3
+  type: archive
+  url: https://proxy.golang.org/github.com/zalando/go-keyring/@v/v0.2.8.zip
 - dest: core/vendor/golang.org/x/oauth2
   sha256: 15bf65ff103e5dafc809d78cd037a1d1e88ccb8451824e851156002a13304504
   strip-components: 3
@@ -122,11 +132,6 @@
   strip-components: 4
   type: archive
   url: https://proxy.golang.org/cloud.google.com/go/compute/metadata/@v/v0.9.0.zip
-- dest: core/vendor/github.com/99designs/go-keychain
-  sha256: ddff1e1a0e673de7d7f40be100b3a4e9b059e290500f17120969f26822a62c64
-  strip-components: 3
-  type: archive
-  url: https://proxy.golang.org/github.com/99designs/go-keychain/@v/v0.0.0-20191008050251-8e49817e8af4.zip
 - dest: core/vendor/github.com/JohannesKaufmann/dom
   sha256: 1f5a5115586c47044df64f3226b135b27df81f3312a859b7da723f761f037a7c
   strip-components: 3
@@ -197,11 +202,6 @@
   strip-components: 4
   type: archive
   url: https://proxy.golang.org/github.com/clipperhouse/uax29/v2/@v/v2.7.0.zip
-- dest: core/vendor/github.com/danieljoos/wincred
-  sha256: a24ece3a299344e6c6cb45da1b5c147e6b14d074a8cfedd7d66488a63ca9dbd5
-  strip-components: 3
-  type: archive
-  url: https://proxy.golang.org/github.com/danieljoos/wincred/@v/v1.2.3.zip
 - dest: core/vendor/github.com/davecgh/go-spew
   sha256: 6b44a843951f371b7010c754ecc3cabefe815d5ced1c5b9409fb2d697e8a890d
   strip-components: 3
@@ -212,11 +212,6 @@
   strip-components: 3
   type: archive
   url: https://proxy.golang.org/github.com/dustin/go-humanize/@v/v1.0.1.zip
-- dest: core/vendor/github.com/dvsekhvalnov/jose2go
-  sha256: 3cfe140e405a123426b17d2a9d56b9f38317822effd738f9509d32932007ee71
-  strip-components: 3
-  type: archive
-  url: https://proxy.golang.org/github.com/dvsekhvalnov/jose2go/@v/v1.8.0.zip
 - dest: core/vendor/github.com/felixge/httpsnoop
   sha256: e3405a361843f8e69f64e41b523512925cd50fd5ea108b7912534922c31b00e7
   strip-components: 3
@@ -242,11 +237,6 @@
   strip-components: 3
   type: archive
   url: https://proxy.golang.org/github.com/go-openapi/inflect/@v/v0.21.6.zip
-- dest: core/vendor/github.com/godbus/dbus
-  sha256: e581c19036afcca2e656efcc4aa99a1348e2f9736177e206990a285d0a1c4c31
-  strip-components: 3
-  type: archive
-  url: https://proxy.golang.org/github.com/godbus/dbus/@v/v0.0.0-20190726142602-4481cbc300e2.zip
 - dest: core/vendor/github.com/google/go-cmp
   sha256: 64a9ce046f2c320e3783fba0d1f4a15f8a18f0b009b67bf27f7630919db3f539
   strip-components: 3
@@ -272,11 +262,6 @@
   strip-components: 3
   type: archive
   url: https://proxy.golang.org/github.com/gorilla/schema/@v/v1.4.1.zip
-- dest: core/vendor/github.com/gsterjov/go-libsecret
-  sha256: cffe0a452fd3f00e4d07730caeb254417a720d907294b5b4a3428322655fb130
-  strip-components: 3
-  type: archive
-  url: https://proxy.golang.org/github.com/gsterjov/go-libsecret/@v/v0.0.0-20161001094733-a6f4afe4910c.zip
 - dest: core/vendor/github.com/hashicorp/hcl/v2
   sha256: 53fd4e96ac9c190e192759daf49b63397865214d337ab5f6dbf6e68c1b0f4810
   strip-components: 4
@@ -312,11 +297,6 @@
   strip-components: 3
   type: archive
   url: https://proxy.golang.org/github.com/mitchellh/go-wordwrap/@v/v1.0.1.zip
-- dest: core/vendor/github.com/mtibben/percent
-  sha256: 21061f4a2b74cb0c65a1c6150e6a1ddbedcd3539a4ef5f0075d1a097f3224ee4
-  strip-components: 3
-  type: archive
-  url: https://proxy.golang.org/github.com/mtibben/percent/@v/v0.2.1.zip
 - dest: core/vendor/github.com/muesli/termenv
   sha256: ba02d3ebd9c1d87e2c2133b1f2bb61a7001b3765196e8016029ce9fe54c5c0fc
   strip-components: 3

--- a/distro/flatpak/modules.txt
+++ b/distro/flatpak/modules.txt
@@ -51,12 +51,6 @@ entgo.io/ent/schema
 entgo.io/ent/schema/edge
 entgo.io/ent/schema/field
 entgo.io/ent/schema/index
-# github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
-## explicit
-github.com/99designs/go-keychain
-# github.com/99designs/keyring v1.2.2
-## explicit; go 1.19
-github.com/99designs/keyring
 # github.com/AvengeMedia/dankgo v0.0.0-20260723140649-8720f7c4d074
 ## explicit; go 1.26
 github.com/AvengeMedia/dankgo/dbusutil
@@ -146,9 +140,6 @@ github.com/danielgtaylor/huma/v2/negotiation
 github.com/danielgtaylor/huma/v2/queryparam
 github.com/danielgtaylor/huma/v2/validation
 github.com/danielgtaylor/huma/v2/yaml
-# github.com/danieljoos/wincred v1.2.3
-## explicit; go 1.18
-github.com/danieljoos/wincred
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
@@ -192,9 +183,6 @@ github.com/go-logr/stdr
 # github.com/go-openapi/inflect v0.21.6
 ## explicit; go 1.25.0
 github.com/go-openapi/inflect
-# github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2
-## explicit; go 1.12
-github.com/godbus/dbus
 # github.com/godbus/dbus/v5 v5.2.2
 ## explicit; go 1.20
 github.com/godbus/dbus/v5
@@ -247,9 +235,6 @@ github.com/googleapis/gax-go/v2/internallog/internal
 # github.com/gorilla/schema v1.4.1
 ## explicit; go 1.20
 github.com/gorilla/schema
-# github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c
-## explicit
-github.com/gsterjov/go-libsecret
 # github.com/hashicorp/hcl/v2 v2.24.0
 ## explicit; go 1.23.0
 github.com/hashicorp/hcl/v2
@@ -334,6 +319,9 @@ github.com/teambition/rrule-go
 # github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e
 ## explicit; go 1.19
 github.com/xo/terminfo
+# github.com/zalando/go-keyring v0.2.8
+## explicit; go 1.18
+github.com/zalando/go-keyring/secret_service
 # github.com/zclconf/go-cty v1.18.1
 ## explicit; go 1.25
 github.com/zclconf/go-cty/cty


### PR DESCRIPTION
Closes #68 

An almost full rewrite to the keyring system, using `zalando/go-keyring` instead of `99designs/keyring` to access the secret service and a newly implemented `file_store` for Flatpak deployments