### PR TITLE
events: add multi-select context actions and clipboard workflows

### DIFF
--- a/quickshell/Common/EventUtils.js
+++ b/quickshell/Common/EventUtils.js
@@ -1,0 +1,141 @@
+.pragma library
+
+var clipboardProductId = "-//Dank Calendar//Event Clipboard 1.0//EN"
+var clipboardDataPrefix = "X-DANKCALENDAR-EVENT:"
+
+function eventKey(event) {
+    return event.id + "|" + event.uid + "|" + new Date(event.start).getTime()
+}
+
+function startOfDay(value) {
+    const date = new Date(value)
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+function daysBetween(from, to) {
+    const fromDay = startOfDay(from)
+    const toDay = startOfDay(to)
+    return Math.round((toDay.getTime() - fromDay.getTime()) / 86400000)
+}
+
+function shiftDate(value, days) {
+    const shifted = new Date(value)
+    shifted.setDate(shifted.getDate() + days)
+    return shifted
+}
+
+function cloneValue(value) {
+    return JSON.parse(JSON.stringify(value || []))
+}
+
+function createFields(event, dayOffset, calendarId, preserveRecurrence) {
+    const fields = {
+        "calendarId": calendarId || event.calendarId,
+        "summary": event.title,
+        "description": event.description || "",
+        "location": event.location || "",
+        "start": shiftDate(event.start, dayOffset).toISOString(),
+        "end": shiftDate(event.end, dayOffset).toISOString(),
+        "allDay": !!event.allDay,
+        "reminders": cloneValue(event.reminders)
+    }
+    if (preserveRecurrence && event.recurrence && event.recurrence.length > 0)
+        fields.recurrence = cloneValue(event.recurrence)
+    return fields
+}
+
+function moveFields(event, dayOffset) {
+    const fields = {
+        "start": shiftDate(event.start, dayOffset).toISOString(),
+        "end": shiftDate(event.end, dayOffset).toISOString()
+    }
+    if ((event.recurringId || "") !== "" || (event.recurrence || []).length > 0)
+        fields.occurrenceStart = new Date(event.start).toISOString()
+    return fields
+}
+
+function sortedUnique(events) {
+    const seen = {}
+    return (events || []).filter(event => {
+        const key = eventKey(event)
+        if (seen[key])
+            return false
+        seen[key] = true
+        return true
+    }).sort((left, right) => {
+        const startDelta = new Date(left.start).getTime() - new Date(right.start).getTime()
+        if (startDelta !== 0)
+            return startDelta
+        return eventKey(left).localeCompare(eventKey(right))
+    })
+}
+
+function escapeICal(value) {
+    return String(value || "").replace(/\\/g, "\\\\").replace(/\r?\n/g, "\\n").replace(/,/g, "\\,").replace(/;/g, "\\;")
+}
+
+function formatICalDate(value, allDay) {
+    const date = new Date(value)
+    const pad = number => String(number).padStart(2, "0")
+    if (allDay)
+        return date.getFullYear() + pad(date.getMonth() + 1) + pad(date.getDate())
+    return date.getUTCFullYear() + pad(date.getUTCMonth() + 1) + pad(date.getUTCDate()) + "T" + pad(date.getUTCHours()) + pad(date.getUTCMinutes()) + pad(date.getUTCSeconds()) + "Z"
+}
+
+function clipboardText(events) {
+    const ordered = sortedUnique(events)
+    const lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:" + clipboardProductId, "CALSCALE:GREGORIAN"]
+    for (let i = 0; i < ordered.length; i++) {
+        const event = ordered[i]
+        const fields = createFields(event, 0, event.calendarId, true)
+        lines.push("BEGIN:VEVENT")
+        lines.push("SUMMARY:" + escapeICal(event.title))
+        if (event.description)
+            lines.push("DESCRIPTION:" + escapeICal(event.description))
+        if (event.location)
+            lines.push("LOCATION:" + escapeICal(event.location))
+        lines.push((event.allDay ? "DTSTART;VALUE=DATE:" : "DTSTART:") + formatICalDate(event.start, event.allDay))
+        lines.push((event.allDay ? "DTEND;VALUE=DATE:" : "DTEND:") + formatICalDate(event.end, event.allDay))
+        lines.push(clipboardDataPrefix + encodeURIComponent(JSON.stringify(fields)))
+        lines.push("END:VEVENT")
+    }
+    lines.push("END:VCALENDAR")
+    return lines.join("\r\n")
+}
+
+function clipboardEvents(text) {
+    if (!text || text.indexOf("BEGIN:VCALENDAR") === -1)
+        return []
+    const lines = String(text).replace(/\r\n/g, "\n").split("\n")
+    const events = []
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].indexOf(clipboardDataPrefix) !== 0)
+            continue
+        try {
+            const fields = JSON.parse(decodeURIComponent(lines[i].substring(clipboardDataPrefix.length)))
+            if (!fields.summary || !fields.start || !fields.end)
+                continue
+            events.push(fields)
+        } catch (error) {
+            // Ignore malformed clipboard entries and keep scanning for others.
+        }
+    }
+    return events
+}
+
+function pasteFields(copiedFields, targetDay, fallbackCalendarId) {
+    if (!copiedFields || copiedFields.length === 0)
+        return []
+    const ordered = copiedFields.slice().sort((left, right) => new Date(left.start) - new Date(right.start))
+    const offset = daysBetween(ordered[0].start, targetDay)
+    return ordered.map(fields => {
+        const copy = Object.assign({}, fields)
+        copy.calendarId = copy.calendarId || fallbackCalendarId
+        copy.start = shiftDate(copy.start, offset).toISOString()
+        copy.end = shiftDate(copy.end, offset).toISOString()
+        copy.reminders = cloneValue(copy.reminders)
+        if (copy.recurrence)
+            copy.recurrence = cloneValue(copy.recurrence)
+        return copy
+    })
+}

--- a/quickshell/Common/EventUtils.js
+++ b/quickshell/Common/EventUtils.js
@@ -87,7 +87,7 @@ function clipboardText(events) {
     const lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:" + clipboardProductId, "CALSCALE:GREGORIAN"]
     for (let i = 0; i < ordered.length; i++) {
         const event = ordered[i]
-        const fields = createFields(event, 0, event.calendarId, true)
+        const fields = createFields(event, 0, event.calendarId, false)
         lines.push("BEGIN:VEVENT")
         lines.push("SUMMARY:" + escapeICal(event.title))
         if (event.description)

--- a/quickshell/Common/EventUtils.js
+++ b/quickshell/Common/EventUtils.js
@@ -74,6 +74,25 @@ function escapeICal(value) {
     return String(value || "").replace(/\\/g, "\\\\").replace(/\r?\n/g, "\\n").replace(/,/g, "\\,").replace(/;/g, "\\;")
 }
 
+// RFC 5545 3.1: content lines longer than 75 octets fold into CRLF + space.
+function foldICalLine(line) {
+    let folded = ""
+    let current = ""
+    let octets = 0
+    for (const character of line) {
+        const encoded = encodeURIComponent(character)
+        const size = encoded.indexOf("%") === 0 ? encoded.length / 3 : 1
+        if (octets + size > 75) {
+            folded += current + "\r\n "
+            current = ""
+            octets = 1
+        }
+        current += character
+        octets += size
+    }
+    return folded + current
+}
+
 function formatICalDate(value, allDay) {
     const date = new Date(value)
     const pad = number => String(number).padStart(2, "0")
@@ -82,11 +101,27 @@ function formatICalDate(value, allDay) {
     return date.getUTCFullYear() + pad(date.getUTCMonth() + 1) + pad(date.getUTCDate()) + "T" + pad(date.getUTCHours()) + pad(date.getUTCMinutes()) + pad(date.getUTCSeconds()) + "Z"
 }
 
-function clipboardText(events, cut) {
-    const ordered = sortedUnique(events)
+function clipboardTextFromFields(fieldsList) {
     const lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:" + clipboardProductId, "CALSCALE:GREGORIAN"]
-    for (let i = 0; i < ordered.length; i++) {
-        const event = ordered[i]
+    for (let i = 0; i < fieldsList.length; i++) {
+        const fields = fieldsList[i]
+        lines.push("BEGIN:VEVENT")
+        lines.push("SUMMARY:" + escapeICal(fields.summary))
+        if (fields.description)
+            lines.push("DESCRIPTION:" + escapeICal(fields.description))
+        if (fields.location)
+            lines.push("LOCATION:" + escapeICal(fields.location))
+        lines.push((fields.allDay ? "DTSTART;VALUE=DATE:" : "DTSTART:") + formatICalDate(fields.start, fields.allDay))
+        lines.push((fields.allDay ? "DTEND;VALUE=DATE:" : "DTEND:") + formatICalDate(fields.end, fields.allDay))
+        lines.push(clipboardDataPrefix + encodeURIComponent(JSON.stringify(fields)))
+        lines.push("END:VEVENT")
+    }
+    lines.push("END:VCALENDAR")
+    return lines.map(foldICalLine).join("\r\n")
+}
+
+function clipboardText(events, cut) {
+    const fieldsList = sortedUnique(events).map(event => {
         const fields = createFields(event, 0, event.calendarId, false)
         if (cut) {
             fields._dankCut = {
@@ -101,25 +136,15 @@ function clipboardText(events, cut) {
                 "recurrence": cloneValue(event.recurrence)
             }
         }
-        lines.push("BEGIN:VEVENT")
-        lines.push("SUMMARY:" + escapeICal(event.title))
-        if (event.description)
-            lines.push("DESCRIPTION:" + escapeICal(event.description))
-        if (event.location)
-            lines.push("LOCATION:" + escapeICal(event.location))
-        lines.push((event.allDay ? "DTSTART;VALUE=DATE:" : "DTSTART:") + formatICalDate(event.start, event.allDay))
-        lines.push((event.allDay ? "DTEND;VALUE=DATE:" : "DTEND:") + formatICalDate(event.end, event.allDay))
-        lines.push(clipboardDataPrefix + encodeURIComponent(JSON.stringify(fields)))
-        lines.push("END:VEVENT")
-    }
-    lines.push("END:VCALENDAR")
-    return lines.join("\r\n")
+        return fields
+    })
+    return clipboardTextFromFields(fieldsList)
 }
 
 function clipboardEvents(text) {
     if (!text || text.indexOf("BEGIN:VCALENDAR") === -1)
         return []
-    const lines = String(text).replace(/\r\n/g, "\n").split("\n")
+    const lines = String(text).replace(/\r?\n[ \t]/g, "").replace(/\r\n/g, "\n").split("\n")
     const events = []
     for (let i = 0; i < lines.length; i++) {
         if (lines[i].indexOf(clipboardDataPrefix) !== 0)

--- a/quickshell/Common/EventUtils.js
+++ b/quickshell/Common/EventUtils.js
@@ -82,12 +82,25 @@ function formatICalDate(value, allDay) {
     return date.getUTCFullYear() + pad(date.getUTCMonth() + 1) + pad(date.getUTCDate()) + "T" + pad(date.getUTCHours()) + pad(date.getUTCMinutes()) + pad(date.getUTCSeconds()) + "Z"
 }
 
-function clipboardText(events) {
+function clipboardText(events, cut) {
     const ordered = sortedUnique(events)
     const lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:" + clipboardProductId, "CALSCALE:GREGORIAN"]
     for (let i = 0; i < ordered.length; i++) {
         const event = ordered[i]
         const fields = createFields(event, 0, event.calendarId, false)
+        if (cut) {
+            fields._dankCut = {
+                "id": event.id,
+                "uid": event.uid || "",
+                "calendarId": event.calendarId,
+                "title": event.title,
+                "start": new Date(event.start).toISOString(),
+                "end": new Date(event.end).toISOString(),
+                "allDay": !!event.allDay,
+                "recurringId": event.recurringId || "",
+                "recurrence": cloneValue(event.recurrence)
+            }
+        }
         lines.push("BEGIN:VEVENT")
         lines.push("SUMMARY:" + escapeICal(event.title))
         if (event.description)

--- a/quickshell/Modals/KeyboardShortcutsOverlay.qml
+++ b/quickshell/Modals/KeyboardShortcutsOverlay.qml
@@ -133,6 +133,35 @@ Item {
             ]
         },
         {
+            "title": I18n.tr("Event actions", "keyboard shortcuts overlay section header"),
+            "rows": [
+                {
+                    "keys": ["Ctrl+C"],
+                    "label": I18n.tr("Copy selected events", "keyboard shortcut description")
+                },
+                {
+                    "keys": ["Ctrl+X"],
+                    "label": I18n.tr("Cut selected events", "keyboard shortcut description")
+                },
+                {
+                    "keys": ["Ctrl+V"],
+                    "label": I18n.tr("Paste events on the selected day", "keyboard shortcut description")
+                },
+                {
+                    "keys": ["Ctrl+D"],
+                    "label": I18n.tr("Duplicate selected events", "keyboard shortcut description")
+                },
+                {
+                    "keys": ["Menu"],
+                    "label": I18n.tr("Open event actions", "keyboard shortcut description")
+                },
+                {
+                    "keys": ["Del", "Backspace"],
+                    "label": I18n.tr("Delete selected events", "keyboard shortcut description")
+                }
+            ]
+        },
+        {
             "title": I18n.tr("General", "keyboard shortcuts overlay section header"),
             "rows": [
                 {

--- a/quickshell/Modals/KeyboardShortcutsOverlay.qml
+++ b/quickshell/Modals/KeyboardShortcutsOverlay.qml
@@ -152,6 +152,22 @@ Item {
                     "label": I18n.tr("Duplicate selected events", "keyboard shortcut description")
                 },
                 {
+                    "keys": ["Ctrl+Shift+D"],
+                    "label": I18n.tr("Duplicate selected events to the next day", "keyboard shortcut description")
+                },
+                {
+                    "keys": ["Ctrl+A"],
+                    "label": I18n.tr("Select all events on the selected day", "keyboard shortcut description")
+                },
+                {
+                    "keys": ["Ctrl+Click"],
+                    "label": I18n.tr("Add or remove an event from the selection", "keyboard shortcut description")
+                },
+                {
+                    "keys": ["Shift+Click"],
+                    "label": I18n.tr("Select a range of events", "keyboard shortcut description")
+                },
+                {
                     "keys": ["Menu"],
                     "label": I18n.tr("Open event actions", "keyboard shortcut description")
                 },

--- a/quickshell/Modules/CalendarContent.qml
+++ b/quickshell/Modules/CalendarContent.qml
@@ -12,6 +12,7 @@ Item {
     property date displayDate: new Date()
     property date selectedDate: new Date()
     property string selectedEventKey: ""
+    property var selectedEventKeys: []
     property date today: new Date()
     property date todayStart: new Date()
     property real rangeStartTime: 0
@@ -22,7 +23,10 @@ Item {
     signal nextRequested
     signal shiftDaysRequested(int days)
     signal createEventRequested
-    signal eventClicked(var event)
+    signal eventClicked(var event, int modifiers)
+    signal eventContextRequested(var event, var anchorItem, real x, real y)
+    signal dayContextRequested(date day, var anchorItem, real x, real y)
+    signal eventDropRequested(var event, date targetDay)
     signal createTaskRequested
     signal taskClicked(var task)
     signal settingsRequested
@@ -193,13 +197,17 @@ Item {
                     displayDate: root.displayDate
                     today: root.today
                     selectedDate: root.selectedDate
+                    selectedEventKeys: root.selectedEventKeys
                     keyRangeStart: root.rangeStartTime
                     keyRangeEnd: root.rangeEndTime
                     onDaySelected: day => root.daySelected(day)
                     onDayActivated: day => root.dayActivated(day)
                     onViewDayRequested: day => root.viewDayRequested(day)
                     onCreateRangeRequested: (startDay, endDay) => root.createRangeRequested(startDay, endDay)
-                    onEventClicked: ev => root.eventClicked(ev)
+                    onEventClicked: (ev, modifiers) => root.eventClicked(ev, modifiers)
+                    onEventContextRequested: (ev, anchorItem, x, y) => root.eventContextRequested(ev, anchorItem, x, y)
+                    onDayContextRequested: (day, anchorItem, x, y) => root.dayContextRequested(day, anchorItem, x, y)
+                    onEventDropRequested: (ev, targetDay) => root.eventDropRequested(ev, targetDay)
                     onPreviousRequested: root.previousRequested()
                     onNextRequested: root.nextRequested()
                 }
@@ -212,7 +220,11 @@ Item {
                     today: root.today
                     selectedDate: root.selectedDate
                     selectedEventKey: root.selectedEventKey
-                    onEventClicked: ev => root.eventClicked(ev)
+                    selectedEventKeys: root.selectedEventKeys
+                    onEventClicked: (ev, modifiers) => root.eventClicked(ev, modifiers)
+                    onEventContextRequested: (ev, anchorItem, x, y) => root.eventContextRequested(ev, anchorItem, x, y)
+                    onDayContextRequested: (day, anchorItem, x, y) => root.dayContextRequested(day, anchorItem, x, y)
+                    onEventDropRequested: (ev, targetDay) => root.eventDropRequested(ev, targetDay)
                     onShiftDaysRequested: days => root.shiftDaysRequested(days)
                 }
             }
@@ -223,7 +235,10 @@ Item {
                     displayDate: root.displayDate
                     today: root.today
                     selectedEventKey: root.selectedEventKey
-                    onEventClicked: ev => root.eventClicked(ev)
+                    selectedEventKeys: root.selectedEventKeys
+                    onEventClicked: (ev, modifiers) => root.eventClicked(ev, modifiers)
+                    onEventContextRequested: (ev, anchorItem, x, y) => root.eventContextRequested(ev, anchorItem, x, y)
+                    onDayContextRequested: (day, anchorItem, x, y) => root.dayContextRequested(day, anchorItem, x, y)
                     onPreviousRequested: root.previousRequested()
                     onNextRequested: root.nextRequested()
                 }
@@ -235,7 +250,10 @@ Item {
                     displayDate: root.displayDate
                     today: root.todayStart
                     selectedEventKey: root.selectedEventKey
-                    onEventClicked: ev => root.eventClicked(ev)
+                    selectedEventKeys: root.selectedEventKeys
+                    onEventClicked: (ev, modifiers) => root.eventClicked(ev, modifiers)
+                    onEventContextRequested: (ev, anchorItem, x, y) => root.eventContextRequested(ev, anchorItem, x, y)
+                    onDayContextRequested: (day, anchorItem, x, y) => root.dayContextRequested(day, anchorItem, x, y)
                 }
             }
 

--- a/quickshell/Modules/CalendarWindow.qml
+++ b/quickshell/Modules/CalendarWindow.qml
@@ -589,6 +589,13 @@ FloatingWindow {
                 }
                 eventSelection.paste(window.selectedDate);
                 break;
+            case Qt.Key_X:
+                if (!ctrl || !eventSelection.hasSelection || !eventSelection.allWritable()) {
+                    event.accepted = false;
+                    return;
+                }
+                eventSelection.cut();
+                break;
             case Qt.Key_Delete:
             case Qt.Key_Backspace:
                 if (!eventSelection.hasSelection || !eventSelection.allWritable()) {

--- a/quickshell/Modules/CalendarWindow.qml
+++ b/quickshell/Modules/CalendarWindow.qml
@@ -32,6 +32,10 @@ FloatingWindow {
     property bool sidebarFocused: false
     property real rangeAnchorTime: 0
 
+    EventSelectionModel {
+        id: eventSelection
+    }
+
     readonly property real selectedDayTime: new Date(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate()).getTime()
     readonly property real rangeStartTime: rangeAnchorTime > 0 ? Math.min(rangeAnchorTime, selectedDayTime) : 0
     readonly property real rangeEndTime: rangeAnchorTime > 0 ? Math.max(rangeAnchorTime, selectedDayTime) : 0
@@ -296,6 +300,28 @@ FloatingWindow {
     function openEventDetails(event) {
         eventLoader.active = true;
         eventLoader.item.show(event);
+    }
+
+    function handleEventClick(event, modifiers) {
+        const selectionModifiers = modifiers || Qt.NoModifier;
+        eventSelection.select(event, selectionModifiers);
+        if ((selectionModifiers & (Qt.ControlModifier | Qt.MetaModifier | Qt.ShiftModifier)) === 0)
+            openEventDetails(event);
+    }
+
+    function handleEventContext(event, anchorItem, x, y) {
+        eventMenu.showForEvent(event, anchorItem, x, y);
+    }
+
+    function requestEventDelete(event) {
+        eventSelection.ensureSelected(event);
+        const count = eventSelection.count;
+        deleteEventsConfirm.show({
+            title: count === 1 ? I18n.tr("Delete event?", "confirmation title for deleting one event") : I18n.tr("Delete %1 events?", "confirmation title for deleting multiple events; %1 is event count").arg(count),
+            message: count === 1 ? I18n.tr("This event will be deleted from its calendar.", "confirmation body for deleting one event") : I18n.tr("These events will be deleted from their calendars. Recurring selections delete only the selected occurrences.", "confirmation body for deleting multiple events"),
+            confirmText: count === 1 ? I18n.tr("Delete event", "confirmation button for deleting one event") : I18n.tr("Delete %1 events", "confirmation button for deleting multiple events; %1 is event count").arg(count),
+            danger: true
+        });
     }
 
     function openCreateEvent(date, endDate) {
@@ -746,6 +772,7 @@ FloatingWindow {
                         displayDate: window.displayDate
                         selectedDate: window.selectedDate
                         selectedEventKey: window.selectedEventKey
+                        selectedEventKeys: eventSelection.selectedKeys
                         today: window.today
                         todayStart: window.todayStart
                         rangeStartTime: window.rangeStartTime
@@ -775,7 +802,10 @@ FloatingWindow {
                             window.displayDate = day;
                             window.currentView = "day";
                         }
-                        onEventClicked: ev => window.openEventDetails(ev)
+                        onEventClicked: (ev, modifiers) => window.handleEventClick(ev, modifiers)
+                        onEventContextRequested: (ev, anchorItem, x, y) => window.handleEventContext(ev, anchorItem, x, y)
+                        onDayContextRequested: (day, anchorItem, x, y) => eventMenu.showForDay(day, anchorItem, x, y)
+                        onEventDropRequested: (ev, targetDay) => eventSelection.moveTo(ev, targetDay)
                         onTaskClicked: task => window.openTaskDetails(task)
                         onCreateTaskRequested: window.openCreateTask()
                     }
@@ -858,6 +888,20 @@ FloatingWindow {
                 onDateSelected: date => window.goToDate(date)
             }
         }
+    }
+
+    EventContextMenu {
+        id: eventMenu
+        controller: eventSelection
+        selectedDay: window.selectedDate
+        onOpenRequested: event => window.openEventDetails(event)
+        onCreateRequested: day => window.openCreateEvent(day)
+        onDeleteRequested: event => window.requestEventDelete(event)
+    }
+
+    ConfirmDialog {
+        id: deleteEventsConfirm
+        onConfirmed: eventSelection.remove()
     }
 
     Toast {

--- a/quickshell/Modules/CalendarWindow.qml
+++ b/quickshell/Modules/CalendarWindow.qml
@@ -188,6 +188,7 @@ FloatingWindow {
         const next = selectedEventIndex + direction;
         if (next >= 0 && next < evs.length) {
             selectedEventIndex = next;
+            eventSelection.replace([evs[next]]);
             return;
         }
         for (let i = 1; i <= 366; i++) {
@@ -198,6 +199,7 @@ FloatingWindow {
                 continue;
             selectedDate = d;
             selectedEventIndex = direction > 0 ? 0 : list.length - 1;
+            eventSelection.replace([list[selectedEventIndex]]);
             ensureSelectionVisible();
             return;
         }
@@ -258,6 +260,13 @@ FloatingWindow {
             rangeAnchorTime = 0;
             openCreateEvent(start, end);
             return;
+        }
+        if (eventSelection.count === 1) {
+            const selected = eventSelection.events();
+            if (selected.length === 1) {
+                openEventDetails(selected[0]);
+                return;
+            }
         }
         const evs = DankCalService.eventsForDay(selectedDate);
         if (selectedEventIndex >= 0 && selectedEventIndex < evs.length) {
@@ -479,6 +488,11 @@ FloatingWindow {
                     window.rangeAnchorTime = 0;
                     break;
                 }
+                if (eventSelection.hasSelection) {
+                    eventSelection.clear();
+                    window.selectedEventIndex = -1;
+                    break;
+                }
                 if (window.selectedEventIndex < 0) {
                     event.accepted = false;
                     return;
@@ -502,9 +516,21 @@ FloatingWindow {
                 window.currentView = "week";
                 break;
             case Qt.Key_D:
+                if (ctrl) {
+                    if (!eventSelection.hasSelection) {
+                        event.accepted = false;
+                        return;
+                    }
+                    eventSelection.duplicate(shift ? 1 : 0);
+                    break;
+                }
                 window.currentView = "day";
                 break;
             case Qt.Key_A:
+                if (ctrl) {
+                    eventSelection.selectDay(window.selectedDate);
+                    break;
+                }
                 window.currentView = "agenda";
                 break;
             case Qt.Key_S:
@@ -546,7 +572,41 @@ FloatingWindow {
                 window.currentView = "tasks";
                 break;
             case Qt.Key_C:
+                if (ctrl) {
+                    if (!eventSelection.hasSelection) {
+                        event.accepted = false;
+                        return;
+                    }
+                    eventSelection.copy();
+                    break;
+                }
                 window.openCreateEvent();
+                break;
+            case Qt.Key_V:
+                if (!ctrl || eventSelection.clipboardCount === 0) {
+                    event.accepted = false;
+                    return;
+                }
+                eventSelection.paste(window.selectedDate);
+                break;
+            case Qt.Key_Delete:
+            case Qt.Key_Backspace:
+                if (!eventSelection.hasSelection || !eventSelection.allWritable()) {
+                    event.accepted = false;
+                    return;
+                }
+                window.requestEventDelete(eventSelection.events()[0]);
+                break;
+            case Qt.Key_Menu:
+                if (!eventSelection.hasSelection) {
+                    event.accepted = false;
+                    return;
+                }
+                {
+                    const selected = eventSelection.events();
+                    if (selected.length > 0)
+                        eventMenu.showForEvent(selected[0], focusScope, focusScope.width / 2, focusScope.height / 2);
+                }
                 break;
             case Qt.Key_Slash:
                 if (shift) {
@@ -819,6 +879,21 @@ FloatingWindow {
             visible: false
             z: 100
             onDismissed: visible = false
+        }
+
+        EventSelectionBar {
+            id: selectionBar
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: Theme.spacingL
+            width: Math.min(implicitWidth, parent.width - Theme.spacingL * 2)
+            z: 90
+            controller: eventSelection
+            onDeleteRequested: {
+                const selected = eventSelection.events();
+                if (selected.length > 0)
+                    window.requestEventDelete(selected[0]);
+            }
         }
     }
 

--- a/quickshell/Modules/CalendarWindow.qml
+++ b/quickshell/Modules/CalendarWindow.qml
@@ -5,6 +5,7 @@ import qs.Modals
 import qs.Services
 import qs.Widgets
 import qs.DankCommon.Widgets
+import "../Common/EventUtils.js" as EventUtils
 
 FloatingWindow {
     id: window
@@ -31,6 +32,7 @@ FloatingWindow {
     property int eventsVersion: 0
     property bool sidebarFocused: false
     property real rangeAnchorTime: 0
+    property var pendingMove: null
 
     EventSelectionModel {
         id: eventSelection
@@ -319,7 +321,31 @@ FloatingWindow {
     }
 
     function handleEventContext(event, anchorItem, x, y) {
-        eventMenu.showForEvent(event, anchorItem, x, y);
+        const position = anchorItem.mapToItem(focusScope, x, y);
+        eventMenu.showForEvent(event, focusScope, position.x, position.y);
+    }
+
+    function handleDayContext(day, anchorItem, x, y) {
+        const position = anchorItem.mapToItem(focusScope, x, y);
+        eventMenu.showForDay(day, focusScope, position.x, position.y);
+    }
+
+    function requestEventMove(event, targetDay) {
+        eventSelection.ensureSelected(event);
+        const movesSeries = eventSelection.events(event).some(ev => (ev.recurringId || "") !== "" || (ev.recurrence || []).length > 0);
+        if (!movesSeries || !eventSelection.allWritable(event) || EventUtils.daysBetween(event.start, targetDay) === 0) {
+            eventSelection.moveTo(event, targetDay);
+            return;
+        }
+        pendingMove = {
+            "event": event,
+            "targetDay": targetDay
+        };
+        moveEventsConfirm.show({
+            title: I18n.tr("Move recurring events?", "confirmation title before moving events that repeat"),
+            message: I18n.tr("Moving a recurring event moves its entire series.", "confirmation body before moving events that repeat"),
+            confirmText: I18n.tr("Move", "confirmation button for moving recurring events")
+        });
     }
 
     function requestEventDelete(event) {
@@ -871,8 +897,8 @@ FloatingWindow {
                         }
                         onEventClicked: (ev, modifiers) => window.handleEventClick(ev, modifiers)
                         onEventContextRequested: (ev, anchorItem, x, y) => window.handleEventContext(ev, anchorItem, x, y)
-                        onDayContextRequested: (day, anchorItem, x, y) => eventMenu.showForDay(day, anchorItem, x, y)
-                        onEventDropRequested: (ev, targetDay) => eventSelection.moveTo(ev, targetDay)
+                        onDayContextRequested: (day, anchorItem, x, y) => window.handleDayContext(day, anchorItem, x, y)
+                        onEventDropRequested: (ev, targetDay) => window.requestEventMove(ev, targetDay)
                         onTaskClicked: task => window.openTaskDetails(task)
                         onCreateTaskRequested: window.openCreateTask()
                     }
@@ -979,11 +1005,22 @@ FloatingWindow {
         onOpenRequested: event => window.openEventDetails(event)
         onCreateRequested: day => window.openCreateEvent(day)
         onDeleteRequested: event => window.requestEventDelete(event)
+        onMoveRequested: (event, day) => window.requestEventMove(event, day)
     }
 
     ConfirmDialog {
         id: deleteEventsConfirm
         onConfirmed: eventSelection.remove()
+    }
+
+    ConfirmDialog {
+        id: moveEventsConfirm
+        onConfirmed: {
+            if (!window.pendingMove)
+                return;
+            eventSelection.moveTo(window.pendingMove.event, window.pendingMove.targetDay);
+            window.pendingMove = null;
+        }
     }
 
     Toast {

--- a/quickshell/Modules/views/AgendaView.qml
+++ b/quickshell/Modules/views/AgendaView.qml
@@ -11,10 +11,13 @@ Item {
     property date displayDate: new Date()
     property date today: new Date()
     property string selectedEventKey: ""
+    property var selectedEventKeys: []
     property int eventsVersion: 0
     readonly property int daysAhead: 14
 
-    signal eventClicked(var event)
+    signal eventClicked(var event, int modifiers)
+    signal eventContextRequested(var event, var anchorItem, real x, real y)
+    signal dayContextRequested(date day, var anchorItem, real x, real y)
 
     function revealItem(item) {
         const y = item.mapToItem(agendaColumn, 0, 0).y;

--- a/quickshell/Modules/views/AgendaView.qml
+++ b/quickshell/Modules/views/AgendaView.qml
@@ -19,6 +19,11 @@ Item {
     signal eventContextRequested(var event, var anchorItem, real x, real y)
     signal dayContextRequested(date day, var anchorItem, real x, real y)
 
+    function isEventSelected(event) {
+        const key = DankCalService.eventKey(event);
+        return selectedEventKey === key || selectedEventKeys.indexOf(key) !== -1;
+    }
+
     function revealItem(item) {
         const y = item.mapToItem(agendaColumn, 0, 0).y;
         if (y < agendaFlickable.contentY) {
@@ -80,6 +85,7 @@ Item {
             });
             out.push({
                 "label": dayLabel(d),
+                "day": d,
                 "events": cards
             });
         }
@@ -124,6 +130,11 @@ Item {
                         font.weight: Font.Medium
                         color: Theme.surfaceText
                         width: parent.width
+
+                        TapHandler {
+                            acceptedButtons: Qt.RightButton
+                            onTapped: eventPoint => root.dayContextRequested(section.modelData.day, parent, eventPoint.position.x, eventPoint.position.y)
+                        }
                     }
 
                     Repeater {
@@ -134,7 +145,7 @@ Item {
                         StyledRect {
                             id: card
                             required property var modelData
-                            readonly property bool isSelected: root.selectedEventKey === DankCalService.eventKey(modelData)
+                            readonly property bool isSelected: root.isEventSelected(modelData)
                             onIsSelectedChanged: {
                                 if (!isSelected)
                                     return;
@@ -145,7 +156,7 @@ Item {
                             }
                             width: root.width
                             height: Math.max(76, contentRow.implicitHeight + Theme.spacingM * 2)
-                            color: Theme.surfaceContainer
+                            color: isSelected ? Theme.primaryBackground : (cardArea.containsMouse ? Theme.surfaceContainerHigh : Theme.surfaceContainer)
                             radius: Theme.cornerRadius
                             border.color: isSelected ? Theme.primary : "transparent"
                             border.width: isSelected ? 2 : 0
@@ -263,10 +274,12 @@ Item {
                                 }
                             }
 
-                            StateLayer {
-                                stateColor: Theme.primary
-                                cornerRadius: parent.radius
-                                onClicked: root.eventClicked(card.modelData)
+                            EventMouseArea {
+                                id: cardArea
+                                anchors.fill: parent
+                                eventData: card.modelData
+                                onActivated: (event, modifiers) => root.eventClicked(event, modifiers)
+                                onContextRequested: (event, anchorItem, x, y) => root.eventContextRequested(event, anchorItem, x, y)
                             }
                         }
                     }

--- a/quickshell/Modules/views/DayView.qml
+++ b/quickshell/Modules/views/DayView.qml
@@ -20,6 +20,11 @@ Item {
     signal previousRequested
     signal nextRequested
 
+    function isEventSelected(event) {
+        const key = DankCalService.eventKey(event);
+        return selectedEventKey === key || selectedEventKeys.indexOf(key) !== -1;
+    }
+
     function revealHours(start, duration) {
         const top = start * hourHeight;
         const bottom = top + duration * hourHeight;
@@ -187,7 +192,7 @@ Item {
 
             Rectangle {
                 required property var modelData
-                readonly property bool isSelected: root.selectedEventKey === DankCalService.eventKey(modelData)
+                readonly property bool isSelected: root.isEventSelected(modelData)
                 width: parent.width
                 height: 22
                 radius: 4
@@ -210,16 +215,16 @@ Item {
                     elide: Text.ElideRight
                 }
 
-                MouseArea {
+                EventMouseArea {
                     anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    hoverEnabled: true
+                    eventData: parent.modelData
                     onEntered: chipTooltip.show(root.eventTooltip(parent.modelData), parent)
                     onExited: chipTooltip.hide()
-                    onClicked: {
+                    onActivated: (event, modifiers) => {
                         chipTooltip.hide();
-                        root.eventClicked(parent.modelData);
+                        root.eventClicked(event, modifiers);
                     }
+                    onContextRequested: (event, anchorItem, x, y) => root.eventContextRequested(event, anchorItem, x, y)
                 }
             }
         }
@@ -339,7 +344,7 @@ Item {
 
                     Rectangle {
                         required property var modelData
-                        readonly property bool isSelected: root.selectedEventKey === DankCalService.eventKey(modelData)
+                        readonly property bool isSelected: root.isEventSelected(modelData)
                         onIsSelectedChanged: {
                             if (isSelected)
                                 root.revealHours(modelData.startHour, modelData.durationHours);
@@ -420,16 +425,16 @@ Item {
                             }
                         }
 
-                        MouseArea {
+                        EventMouseArea {
                             anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            hoverEnabled: true
+                            eventData: parent.modelData
                             onEntered: chipTooltip.show(root.eventTooltip(parent.modelData), parent)
                             onExited: chipTooltip.hide()
-                            onClicked: {
+                            onActivated: (event, modifiers) => {
                                 chipTooltip.hide();
-                                root.eventClicked(parent.modelData);
+                                root.eventClicked(event, modifiers);
                             }
+                            onContextRequested: (event, anchorItem, x, y) => root.eventContextRequested(event, anchorItem, x, y)
                         }
                     }
                 }
@@ -453,5 +458,10 @@ Item {
 
     DankSlideDragHandler {
         slideArea: slidePager
+    }
+
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        onTapped: eventPoint => root.dayContextRequested(root.displayDate, root, eventPoint.position.x, eventPoint.position.y)
     }
 }

--- a/quickshell/Modules/views/DayView.qml
+++ b/quickshell/Modules/views/DayView.qml
@@ -11,9 +11,12 @@ Item {
     property date displayDate: new Date()
     property date today: new Date()
     property string selectedEventKey: ""
+    property var selectedEventKeys: []
     property int eventsVersion: 0
 
-    signal eventClicked(var event)
+    signal eventClicked(var event, int modifiers)
+    signal eventContextRequested(var event, var anchorItem, real x, real y)
+    signal dayContextRequested(date day, var anchorItem, real x, real y)
     signal previousRequested
     signal nextRequested
 

--- a/quickshell/Modules/views/MonthDayPopover.qml
+++ b/quickshell/Modules/views/MonthDayPopover.qml
@@ -11,8 +11,10 @@ Item {
 
     property var events: []
     property date day: new Date()
+    property var selectedEventKeys: []
 
-    signal eventClicked(var event)
+    signal eventClicked(var event, int modifiers)
+    signal eventContextRequested(var event, var anchorItem, real x, real y)
 
     readonly property int rowHeight: 38
     readonly property int headerHeight: 40
@@ -131,10 +133,13 @@ Item {
                 delegate: Rectangle {
                     id: eventRow
                     required property var modelData
+                    readonly property bool isSelected: root.selectedEventKeys.indexOf(DankCalService.eventKey(modelData)) !== -1
                     width: ListView.view.width
                     height: root.rowHeight - 2
                     radius: 4
-                    color: rowHover.containsMouse ? Theme.withAlpha(modelData.color, 0.18) : "transparent"
+                    color: isSelected ? Theme.withAlpha(modelData.color, 0.28) : (rowHover.containsMouse ? Theme.withAlpha(modelData.color, 0.18) : "transparent")
+                    border.color: isSelected ? Theme.primary : "transparent"
+                    border.width: isSelected ? 2 : 0
 
                     Row {
                         anchors.left: parent.left
@@ -176,11 +181,17 @@ Item {
                     MouseArea {
                         id: rowHover
                         anchors.fill: parent
+                        acceptedButtons: Qt.LeftButton | Qt.RightButton
                         hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
-                        onClicked: {
-                            root.eventClicked(eventRow.modelData);
-                            popup.close();
+                        onClicked: mouse => {
+                            if (mouse.button === Qt.RightButton) {
+                                root.eventContextRequested(eventRow.modelData, eventRow, mouse.x, mouse.y);
+                                return;
+                            }
+                            root.eventClicked(eventRow.modelData, mouse.modifiers);
+                            if ((mouse.modifiers & (Qt.ControlModifier | Qt.MetaModifier | Qt.ShiftModifier)) === 0)
+                                popup.close();
                         }
                     }
                 }

--- a/quickshell/Modules/views/MonthDayPopover.qml
+++ b/quickshell/Modules/views/MonthDayPopover.qml
@@ -21,6 +21,10 @@ Item {
     readonly property int maxBodyHeight: 320
     readonly property int popoverWidth: 300
 
+    function isEventSelected(event) {
+        return selectedEventKeys.indexOf(DankCalService.eventKey(event)) !== -1;
+    }
+
     function show(forDay, dayEvents, item) {
         if (!item)
             return;
@@ -133,7 +137,7 @@ Item {
                 delegate: Rectangle {
                     id: eventRow
                     required property var modelData
-                    readonly property bool isSelected: root.selectedEventKeys.indexOf(DankCalService.eventKey(modelData)) !== -1
+                    readonly property bool isSelected: root.isEventSelected(modelData)
                     width: ListView.view.width
                     height: root.rowHeight - 2
                     radius: 4

--- a/quickshell/Modules/views/MonthView.qml
+++ b/quickshell/Modules/views/MonthView.qml
@@ -41,10 +41,18 @@ Item {
     readonly property real previewStart: dragSelecting ? dragRangeStart : keyRangeStart
     readonly property real previewEnd: dragSelecting ? dragRangeEnd : keyRangeEnd
 
+    function isEventSelected(event) {
+        return selectedEventKeys.indexOf(DankCalService.eventKey(event)) !== -1;
+    }
+
     function updateEventDrag(pointerItem, x, y) {
         const gridPosition = pointerItem.mapToItem(grid, x, y);
         const rootPosition = pointerItem.mapToItem(root, x, y);
         dragPosition = Qt.point(rootPosition.x, rootPosition.y);
+        if (gridPosition.x < 0 || gridPosition.x >= grid.width || gridPosition.y < 0 || gridPosition.y >= grid.height) {
+            dragTargetTime = 0;
+            return;
+        }
         const target = rangeDrag.dateAt(gridPosition);
         dragTargetTime = target ? target.getTime() : 0;
     }
@@ -450,7 +458,7 @@ Item {
 
                                 Rectangle {
                                     required property var modelData
-                                    readonly property bool isSelected: root.selectedEventKeys.indexOf(DankCalService.eventKey(modelData)) !== -1
+                                    readonly property bool isSelected: root.isEventSelected(modelData)
                                     width: parent.width
                                     height: root.eventChipHeight
                                     radius: 4
@@ -563,27 +571,10 @@ Item {
         onStepped: direction => wheelHandler.step((I18n.isRtl ? 1 : -1) * direction)
     }
 
-    Rectangle {
-        visible: root.eventDragging && root.draggedEvent
-        x: Math.min(root.width - width - Theme.spacingS, Math.max(Theme.spacingS, root.dragPosition.x + 12))
-        y: Math.min(root.height - height - Theme.spacingS, Math.max(Theme.spacingS, root.dragPosition.y + 12))
-        width: Math.min(220, dragLabel.implicitWidth + Theme.spacingL * 2)
-        height: 34
-        radius: Theme.cornerRadiusSmall
-        color: Theme.surfaceContainerHigh
-        border.color: Theme.primary
-        border.width: 2
-        z: 100
-
-        StyledText {
-            id: dragLabel
-            anchors.centerIn: parent
-            text: root.selectedEventKeys.indexOf(root.draggedEvent ? DankCalService.eventKey(root.draggedEvent) : "") !== -1 && root.selectedEventKeys.length > 1 ? I18n.tr("Move %1 events", "event drag preview label; %1 is event count").arg(root.selectedEventKeys.length) : (root.draggedEvent ? root.draggedEvent.title : "")
-            font.pixelSize: Theme.fontSizeSmall
-            font.weight: Font.Medium
-            color: Theme.surfaceText
-            elide: Text.ElideRight
-            width: Math.min(196, implicitWidth)
-        }
+    EventDragGhost {
+        dragging: root.eventDragging
+        draggedEvent: root.draggedEvent
+        dragPosition: root.dragPosition
+        selectedKeys: root.selectedEventKeys
     }
 }

--- a/quickshell/Modules/views/MonthView.qml
+++ b/quickshell/Modules/views/MonthView.qml
@@ -12,10 +12,14 @@ Item {
     property date today: new Date()
     property date selectedDate: new Date()
     property int eventsVersion: 0
+    property var selectedEventKeys: []
 
     signal daySelected(date day)
     signal dayActivated(date day)
-    signal eventClicked(var event)
+    signal eventClicked(var event, int modifiers)
+    signal eventContextRequested(var event, var anchorItem, real x, real y)
+    signal dayContextRequested(date day, var anchorItem, real x, real y)
+    signal eventDropRequested(var event, date targetDay)
     signal viewDayRequested(date day)
     signal previousRequested
     signal nextRequested

--- a/quickshell/Modules/views/MonthView.qml
+++ b/quickshell/Modules/views/MonthView.qml
@@ -107,7 +107,9 @@ Item {
 
     MonthDayPopover {
         id: dayPopover
-        onEventClicked: ev => root.eventClicked(ev)
+        selectedEventKeys: root.selectedEventKeys
+        onEventClicked: (ev, modifiers) => root.eventClicked(ev, modifiers)
+        onEventContextRequested: (ev, anchorItem, x, y) => root.eventContextRequested(ev, anchorItem, x, y)
     }
 
     function eventTooltip(ev) {
@@ -412,11 +414,14 @@ Item {
 
                                 Rectangle {
                                     required property var modelData
+                                    readonly property bool isSelected: root.selectedEventKeys.indexOf(DankCalService.eventKey(modelData)) !== -1
                                     width: parent.width
                                     height: root.eventChipHeight
                                     radius: 4
                                     clip: true
-                                    color: Theme.withAlpha(modelData.color, 0.18)
+                                    color: Theme.withAlpha(modelData.color, isSelected ? 0.32 : 0.18)
+                                    border.color: isSelected ? Theme.primary : "transparent"
+                                    border.width: isSelected ? 2 : 0
 
                                     Row {
                                         anchors.left: parent.left
@@ -448,6 +453,7 @@ Item {
 
                                     MouseArea {
                                         anchors.fill: parent
+                                        acceptedButtons: Qt.LeftButton | Qt.RightButton
                                         cursorShape: Qt.PointingHandCursor
                                         hoverEnabled: true
                                         onEntered: chipTooltip.show(root.eventTooltip(parent.modelData), parent)
@@ -455,7 +461,11 @@ Item {
                                         onClicked: mouse => {
                                             mouse.accepted = true;
                                             chipTooltip.hide();
-                                            root.eventClicked(parent.modelData);
+                                            if (mouse.button === Qt.RightButton) {
+                                                root.eventContextRequested(parent.modelData, parent, mouse.x, mouse.y);
+                                                return;
+                                            }
+                                            root.eventClicked(parent.modelData, mouse.modifiers);
                                         }
                                     }
                                 }
@@ -481,8 +491,14 @@ Item {
                         }
 
                         TapHandler {
-                            acceptedButtons: Qt.LeftButton
-                            onTapped: root.daySelected(dayCell.cellDate)
+                            acceptedButtons: Qt.LeftButton | Qt.RightButton
+                            onTapped: (eventPoint, button) => {
+                                if (button === Qt.RightButton) {
+                                    root.dayContextRequested(dayCell.cellDate, dayCell, eventPoint.position.x, eventPoint.position.y);
+                                    return;
+                                }
+                                root.daySelected(dayCell.cellDate);
+                            }
                             onDoubleTapped: root.dayActivated(dayCell.cellDate)
                         }
                     }

--- a/quickshell/Modules/views/MonthView.qml
+++ b/quickshell/Modules/views/MonthView.qml
@@ -31,10 +31,33 @@ Item {
     property real dragRangeEnd: 0
     property real keyRangeStart: 0
     property real keyRangeEnd: 0
+    property bool eventPointerDown: false
+    property bool eventDragging: false
+    property var draggedEvent: null
+    property real dragTargetTime: 0
+    property point dragPosition: Qt.point(0, 0)
 
     readonly property bool previewActive: dragSelecting || keyRangeStart > 0
     readonly property real previewStart: dragSelecting ? dragRangeStart : keyRangeStart
     readonly property real previewEnd: dragSelecting ? dragRangeEnd : keyRangeEnd
+
+    function updateEventDrag(pointerItem, x, y) {
+        const gridPosition = pointerItem.mapToItem(grid, x, y);
+        const rootPosition = pointerItem.mapToItem(root, x, y);
+        dragPosition = Qt.point(rootPosition.x, rootPosition.y);
+        const target = rangeDrag.dateAt(gridPosition);
+        dragTargetTime = target ? target.getTime() : 0;
+    }
+
+    function finishEventDrag(event) {
+        const targetTime = dragTargetTime;
+        eventPointerDown = false;
+        eventDragging = false;
+        draggedEvent = null;
+        dragTargetTime = 0;
+        if (targetTime > 0)
+            eventDropRequested(event, new Date(targetTime));
+    }
 
     Timer {
         id: scrollCooldown
@@ -223,6 +246,7 @@ Item {
 
                 DragHandler {
                     id: rangeDrag
+                    enabled: !root.eventPointerDown && !root.eventDragging
 
                     function dateAt(pos) {
                         const x = Math.min(Math.max(pos.x, 0), grid.width - 1);
@@ -274,6 +298,7 @@ Item {
                         readonly property bool isToday: root.isSameDay(cellDate, root.today)
                         readonly property bool isSelected: root.isSameDay(cellDate, root.selectedDate)
                         readonly property bool inPreviewRange: root.previewActive && cellDate.getTime() >= root.previewStart && cellDate.getTime() <= root.previewEnd
+                        readonly property bool isDropTarget: root.eventDragging && cellDate.getTime() === root.dragTargetTime
                         readonly property bool previewLeading: inPreviewRange && cellDate.getTime() === (I18n.isRtl ? root.previewEnd : root.previewStart)
                         readonly property bool previewTrailing: inPreviewRange && cellDate.getTime() === (I18n.isRtl ? root.previewStart : root.previewEnd)
                         readonly property var cellEvents: {
@@ -323,6 +348,17 @@ Item {
                             border.color: Theme.primary
                             border.width: 1
                             radius: Theme.cornerRadiusSmall
+                        }
+
+                        Rectangle {
+                            visible: dayCell.isDropTarget
+                            anchors.fill: parent
+                            anchors.margins: 2
+                            color: Theme.withAlpha(Theme.primary, 0.12)
+                            border.color: Theme.primary
+                            border.width: 2
+                            radius: Theme.cornerRadiusSmall
+                            z: 4
                         }
 
                         Rectangle {
@@ -451,21 +487,33 @@ Item {
                                         }
                                     }
 
-                                    MouseArea {
+                                    EventMouseArea {
                                         anchors.fill: parent
-                                        acceptedButtons: Qt.LeftButton | Qt.RightButton
-                                        cursorShape: Qt.PointingHandCursor
-                                        hoverEnabled: true
+                                        eventData: parent.modelData
+                                        dragEnabled: !parent.modelData.readOnly
                                         onEntered: chipTooltip.show(root.eventTooltip(parent.modelData), parent)
                                         onExited: chipTooltip.hide()
-                                        onClicked: mouse => {
-                                            mouse.accepted = true;
+                                        onActivated: (event, modifiers) => {
                                             chipTooltip.hide();
-                                            if (mouse.button === Qt.RightButton) {
-                                                root.eventContextRequested(parent.modelData, parent, mouse.x, mouse.y);
-                                                return;
-                                            }
-                                            root.eventClicked(parent.modelData, mouse.modifiers);
+                                            root.eventClicked(event, modifiers);
+                                        }
+                                        onContextRequested: (event, anchorItem, x, y) => root.eventContextRequested(event, anchorItem, x, y)
+                                        onDragPressed: root.eventPointerDown = true
+                                        onDragStarted: (event, pointerItem, x, y) => {
+                                            chipTooltip.hide();
+                                            root.draggedEvent = event;
+                                            root.eventDragging = true;
+                                            root.updateEventDrag(pointerItem, x, y);
+                                        }
+                                        onDragMoved: (event, pointerItem, x, y) => root.updateEventDrag(pointerItem, x, y)
+                                        onDropped: (event, pointerItem, x, y) => {
+                                            root.updateEventDrag(pointerItem, x, y);
+                                            root.finishEventDrag(event);
+                                        }
+                                        onDragReleased: {
+                                            root.eventPointerDown = false;
+                                            if (root.eventDragging)
+                                                root.finishEventDrag(parent.modelData);
                                         }
                                     }
                                 }
@@ -513,5 +561,29 @@ Item {
         continuous: false
         dragEnabled: false
         onStepped: direction => wheelHandler.step((I18n.isRtl ? 1 : -1) * direction)
+    }
+
+    Rectangle {
+        visible: root.eventDragging && root.draggedEvent
+        x: Math.min(root.width - width - Theme.spacingS, Math.max(Theme.spacingS, root.dragPosition.x + 12))
+        y: Math.min(root.height - height - Theme.spacingS, Math.max(Theme.spacingS, root.dragPosition.y + 12))
+        width: Math.min(220, dragLabel.implicitWidth + Theme.spacingL * 2)
+        height: 34
+        radius: Theme.cornerRadiusSmall
+        color: Theme.surfaceContainerHigh
+        border.color: Theme.primary
+        border.width: 2
+        z: 100
+
+        StyledText {
+            id: dragLabel
+            anchors.centerIn: parent
+            text: root.selectedEventKeys.indexOf(root.draggedEvent ? DankCalService.eventKey(root.draggedEvent) : "") !== -1 && root.selectedEventKeys.length > 1 ? I18n.tr("Move %1 events", "event drag preview label; %1 is event count").arg(root.selectedEventKeys.length) : (root.draggedEvent ? root.draggedEvent.title : "")
+            font.pixelSize: Theme.fontSizeSmall
+            font.weight: Font.Medium
+            color: Theme.surfaceText
+            elide: Text.ElideRight
+            width: Math.min(196, implicitWidth)
+        }
     }
 }

--- a/quickshell/Modules/views/WeekView.qml
+++ b/quickshell/Modules/views/WeekView.qml
@@ -14,12 +14,44 @@ Item {
     property string selectedEventKey: ""
     property var selectedEventKeys: []
     property int eventsVersion: 0
+    property bool eventPointerDown: false
+    property bool eventDragging: false
+    property var draggedEvent: null
+    property real dragTargetTime: 0
+    property point dragPosition: Qt.point(0, 0)
 
     signal eventClicked(var event, int modifiers)
     signal eventContextRequested(var event, var anchorItem, real x, real y)
     signal dayContextRequested(date day, var anchorItem, real x, real y)
     signal eventDropRequested(var event, date targetDay)
     signal shiftDaysRequested(int days)
+
+    function isEventSelected(event) {
+        const key = DankCalService.eventKey(event);
+        return selectedEventKey === key || selectedEventKeys.indexOf(key) !== -1;
+    }
+
+    function updateEventDrag(pointerItem, x, y) {
+        const position = pointerItem.mapToItem(root, x, y);
+        dragPosition = Qt.point(position.x, position.y);
+        if (position.x < timeColumnWidth || position.x >= width) {
+            dragTargetTime = 0;
+            return;
+        }
+        const visualIndex = Math.floor((position.x - timeColumnWidth - slidePx) / dayWidth);
+        const dayIndex = I18n.isRtl ? 6 - visualIndex : visualIndex;
+        dragTargetTime = dayAt(dayIndex).getTime();
+    }
+
+    function finishEventDrag(event) {
+        const targetTime = dragTargetTime;
+        eventPointerDown = false;
+        eventDragging = false;
+        draggedEvent = null;
+        dragTargetTime = 0;
+        if (targetTime > 0)
+            eventDropRequested(event, new Date(targetTime));
+    }
 
     function revealHours(start, duration) {
         const top = start * hourHeight;
@@ -330,6 +362,11 @@ Item {
                                 height: 1
                                 color: Theme.gridLine
                             }
+
+                            TapHandler {
+                                acceptedButtons: Qt.RightButton
+                                onTapped: eventPoint => root.dayContextRequested(parent.d, parent, eventPoint.position.x, eventPoint.position.y)
+                            }
                         }
                     }
                 }
@@ -369,6 +406,8 @@ Item {
                         Item {
                             id: allDayCell
                             required property int index
+                            readonly property date day: root.dayAt(index - 1)
+                            readonly property bool isDropTarget: root.eventDragging && day.getTime() === root.dragTargetTime
                             readonly property var dayEvents: {
                                 root.eventsVersion;
                                 return root.allDayEventsFor(root.dayAt(index - 1));
@@ -376,6 +415,16 @@ Item {
 
                             width: root.dayWidth
                             height: parent.height
+
+                            Rectangle {
+                                visible: allDayCell.isDropTarget
+                                anchors.fill: parent
+                                anchors.margins: 1
+                                color: Theme.withAlpha(Theme.primary, 0.12)
+                                border.color: Theme.primary
+                                border.width: 2
+                                radius: Theme.cornerRadiusSmall
+                            }
 
                             Column {
                                 anchors.fill: parent
@@ -389,7 +438,7 @@ Item {
 
                                     Rectangle {
                                         required property var modelData
-                                        readonly property bool isSelected: root.selectedEventKey === DankCalService.eventKey(modelData)
+                                        readonly property bool isSelected: root.isEventSelected(modelData)
                                         width: parent.width
                                         height: root.allDayChipHeight
                                         radius: 4
@@ -412,15 +461,33 @@ Item {
                                             elide: Text.ElideRight
                                         }
 
-                                        MouseArea {
+                                        EventMouseArea {
                                             anchors.fill: parent
-                                            cursorShape: Qt.PointingHandCursor
-                                            hoverEnabled: true
+                                            eventData: parent.modelData
+                                            dragEnabled: !parent.modelData.readOnly
                                             onEntered: chipTooltip.show(root.eventTooltip(parent.modelData), parent)
                                             onExited: chipTooltip.hide()
-                                            onClicked: {
+                                            onActivated: (event, modifiers) => {
                                                 chipTooltip.hide();
-                                                root.eventClicked(parent.modelData);
+                                                root.eventClicked(event, modifiers);
+                                            }
+                                            onContextRequested: (event, anchorItem, x, y) => root.eventContextRequested(event, anchorItem, x, y)
+                                            onDragPressed: root.eventPointerDown = true
+                                            onDragStarted: (event, pointerItem, x, y) => {
+                                                chipTooltip.hide();
+                                                root.draggedEvent = event;
+                                                root.eventDragging = true;
+                                                root.updateEventDrag(pointerItem, x, y);
+                                            }
+                                            onDragMoved: (event, pointerItem, x, y) => root.updateEventDrag(pointerItem, x, y)
+                                            onDropped: (event, pointerItem, x, y) => {
+                                                root.updateEventDrag(pointerItem, x, y);
+                                                root.finishEventDrag(event);
+                                            }
+                                            onDragReleased: {
+                                                root.eventPointerDown = false;
+                                                if (root.eventDragging)
+                                                    root.finishEventDrag(parent.modelData);
                                             }
                                         }
                                     }
@@ -570,6 +637,8 @@ Item {
                             Item {
                                 id: dayColumn
                                 required property int index
+                                readonly property date day: root.dayAt(index - 1)
+                                readonly property bool isDropTarget: root.eventDragging && day.getTime() === root.dragTargetTime
                                 readonly property var timedEvents: {
                                     root.eventsVersion;
                                     return root.timedEventsFor(root.dayAt(index - 1));
@@ -577,6 +646,16 @@ Item {
 
                                 width: root.dayWidth
                                 height: parent.height
+
+                                Rectangle {
+                                    visible: dayColumn.isDropTarget
+                                    anchors.fill: parent
+                                    anchors.margins: 1
+                                    color: Theme.withAlpha(Theme.primary, 0.1)
+                                    border.color: Theme.primary
+                                    border.width: 2
+                                    radius: Theme.cornerRadiusSmall
+                                }
 
                                 Rectangle {
                                     anchors.left: parent.left
@@ -604,7 +683,7 @@ Item {
 
                                     Rectangle {
                                         required property var modelData
-                                        readonly property bool isSelected: root.selectedEventKey === DankCalService.eventKey(modelData)
+                                        readonly property bool isSelected: root.isEventSelected(modelData)
                                         onIsSelectedChanged: {
                                             if (isSelected)
                                                 root.revealHours(modelData.startHour, modelData.durationHours);
@@ -650,18 +729,41 @@ Item {
                                             }
                                         }
 
-                                        MouseArea {
+                                        EventMouseArea {
                                             anchors.fill: parent
-                                            cursorShape: Qt.PointingHandCursor
-                                            hoverEnabled: true
+                                            eventData: parent.modelData
+                                            dragEnabled: !parent.modelData.readOnly
                                             onEntered: chipTooltip.show(root.eventTooltip(parent.modelData), parent)
                                             onExited: chipTooltip.hide()
-                                            onClicked: {
+                                            onActivated: (event, modifiers) => {
                                                 chipTooltip.hide();
-                                                root.eventClicked(parent.modelData);
+                                                root.eventClicked(event, modifiers);
+                                            }
+                                            onContextRequested: (event, anchorItem, x, y) => root.eventContextRequested(event, anchorItem, x, y)
+                                            onDragPressed: root.eventPointerDown = true
+                                            onDragStarted: (event, pointerItem, x, y) => {
+                                                chipTooltip.hide();
+                                                root.draggedEvent = event;
+                                                root.eventDragging = true;
+                                                root.updateEventDrag(pointerItem, x, y);
+                                            }
+                                            onDragMoved: (event, pointerItem, x, y) => root.updateEventDrag(pointerItem, x, y)
+                                            onDropped: (event, pointerItem, x, y) => {
+                                                root.updateEventDrag(pointerItem, x, y);
+                                                root.finishEventDrag(event);
+                                            }
+                                            onDragReleased: {
+                                                root.eventPointerDown = false;
+                                                if (root.eventDragging)
+                                                    root.finishEventDrag(parent.modelData);
                                             }
                                         }
                                     }
+                                }
+
+                                TapHandler {
+                                    acceptedButtons: Qt.RightButton
+                                    onTapped: eventPoint => root.dayContextRequested(dayColumn.day, dayColumn, eventPoint.position.x, eventPoint.position.y)
                                 }
                             }
                         }
@@ -715,6 +817,7 @@ Item {
         id: slidePager
         anchors.fill: parent
         z: 50
+        dragEnabled: !root.eventPointerDown && !root.eventDragging
         onMoved: dx => root.applySlide(dx)
         onStepped: direction => root.slideDays((I18n.isRtl ? 1 : -1) * direction)
         onSettled: root.settleSlide()
@@ -722,5 +825,29 @@ Item {
 
     DankSlideDragHandler {
         slideArea: slidePager
+    }
+
+    Rectangle {
+        visible: root.eventDragging && root.draggedEvent
+        x: Math.min(root.width - width - Theme.spacingS, Math.max(Theme.spacingS, root.dragPosition.x + 12))
+        y: Math.min(root.height - height - Theme.spacingS, Math.max(Theme.spacingS, root.dragPosition.y + 12))
+        width: Math.min(220, dragLabel.implicitWidth + Theme.spacingL * 2)
+        height: 34
+        radius: Theme.cornerRadiusSmall
+        color: Theme.surfaceContainerHigh
+        border.color: Theme.primary
+        border.width: 2
+        z: 100
+
+        StyledText {
+            id: dragLabel
+            anchors.centerIn: parent
+            text: root.selectedEventKeys.indexOf(root.draggedEvent ? DankCalService.eventKey(root.draggedEvent) : "") !== -1 && root.selectedEventKeys.length > 1 ? I18n.tr("Move %1 events", "event drag preview label; %1 is event count").arg(root.selectedEventKeys.length) : (root.draggedEvent ? root.draggedEvent.title : "")
+            font.pixelSize: Theme.fontSizeSmall
+            font.weight: Font.Medium
+            color: Theme.surfaceText
+            elide: Text.ElideRight
+            width: Math.min(196, implicitWidth)
+        }
     }
 }

--- a/quickshell/Modules/views/WeekView.qml
+++ b/quickshell/Modules/views/WeekView.qml
@@ -39,6 +39,10 @@ Item {
             return;
         }
         const visualIndex = Math.floor((position.x - timeColumnWidth - slidePx) / dayWidth);
+        if (visualIndex < 0 || visualIndex > 6) {
+            dragTargetTime = 0;
+            return;
+        }
         const dayIndex = I18n.isRtl ? 6 - visualIndex : visualIndex;
         dragTargetTime = dayAt(dayIndex).getTime();
     }
@@ -827,27 +831,10 @@ Item {
         slideArea: slidePager
     }
 
-    Rectangle {
-        visible: root.eventDragging && root.draggedEvent
-        x: Math.min(root.width - width - Theme.spacingS, Math.max(Theme.spacingS, root.dragPosition.x + 12))
-        y: Math.min(root.height - height - Theme.spacingS, Math.max(Theme.spacingS, root.dragPosition.y + 12))
-        width: Math.min(220, dragLabel.implicitWidth + Theme.spacingL * 2)
-        height: 34
-        radius: Theme.cornerRadiusSmall
-        color: Theme.surfaceContainerHigh
-        border.color: Theme.primary
-        border.width: 2
-        z: 100
-
-        StyledText {
-            id: dragLabel
-            anchors.centerIn: parent
-            text: root.selectedEventKeys.indexOf(root.draggedEvent ? DankCalService.eventKey(root.draggedEvent) : "") !== -1 && root.selectedEventKeys.length > 1 ? I18n.tr("Move %1 events", "event drag preview label; %1 is event count").arg(root.selectedEventKeys.length) : (root.draggedEvent ? root.draggedEvent.title : "")
-            font.pixelSize: Theme.fontSizeSmall
-            font.weight: Font.Medium
-            color: Theme.surfaceText
-            elide: Text.ElideRight
-            width: Math.min(196, implicitWidth)
-        }
+    EventDragGhost {
+        dragging: root.eventDragging
+        draggedEvent: root.draggedEvent
+        dragPosition: root.dragPosition
+        selectedKeys: root.selectedEventKeys
     }
 }

--- a/quickshell/Modules/views/WeekView.qml
+++ b/quickshell/Modules/views/WeekView.qml
@@ -12,9 +12,13 @@ Item {
     property date today: new Date()
     property date selectedDate: new Date()
     property string selectedEventKey: ""
+    property var selectedEventKeys: []
     property int eventsVersion: 0
 
-    signal eventClicked(var event)
+    signal eventClicked(var event, int modifiers)
+    signal eventContextRequested(var event, var anchorItem, real x, real y)
+    signal dayContextRequested(date day, var anchorItem, real x, real y)
+    signal eventDropRequested(var event, date targetDay)
     signal shiftDaysRequested(int days)
 
     function revealHours(start, duration) {

--- a/quickshell/Services/DankCalService.qml
+++ b/quickshell/Services/DankCalService.qml
@@ -7,6 +7,7 @@ import Quickshell.Io
 import qs.Common
 import qs.DankCommon.Common
 import qs.Services
+import "../Common/EventUtils.js" as EventUtils
 
 Singleton {
     id: root
@@ -671,7 +672,28 @@ Singleton {
     // Occurrence identity for selection: recurring occurrences share a uid and
     // may have an empty id, so both plus the start instant are needed.
     function eventKey(ev) {
-        return ev.id + "|" + ev.uid + "|" + ev.start.getTime();
+        return EventUtils.eventKey(ev);
+    }
+
+    function visibleEvents() {
+        const hidden = _hiddenCalendarIds();
+        return events.filter(ev => !hidden[ev.calendarId] && ev.status !== "cancelled").map(ev => decorateEvent(ev)).sort((left, right) => {
+            const startDelta = left.start.getTime() - right.start.getTime();
+            if (startDelta !== 0)
+                return startDelta;
+            if (left.allDay !== right.allDay)
+                return left.allDay ? -1 : 1;
+            return eventKey(left).localeCompare(eventKey(right));
+        });
+    }
+
+    function eventsByKeys(keys) {
+        if (!keys || keys.length === 0)
+            return [];
+        const wanted = {};
+        for (let i = 0; i < keys.length; i++)
+            wanted[keys[i]] = true;
+        return visibleEvents().filter(ev => wanted[eventKey(ev)]);
     }
 
     function layoutTimedEvents(events) {
@@ -790,6 +812,75 @@ Singleton {
             if (callback)
                 callback(response);
         });
+    }
+
+    function mutateEvents(method, paramsList, callback) {
+        const queue = paramsList || [];
+        const results = [];
+        const errors = [];
+        let index = 0;
+
+        const finish = () => {
+            reloadEvents();
+            const response = {
+                "results": results,
+                "errors": errors
+            };
+            if (errors.length > 0) {
+                response.error = errors[0];
+                lastError = errors[0];
+            }
+            if (callback)
+                callback(response);
+        };
+
+        const sendNext = () => {
+            if (index >= queue.length) {
+                finish();
+                return;
+            }
+            sendRequest(method, queue[index], response => {
+                if (response.error)
+                    errors.push(response.error);
+                else
+                    results.push(response.result);
+                index++;
+                sendNext();
+            });
+        };
+
+        if (queue.length === 0) {
+            if (callback)
+                callback({
+                    "results": [],
+                    "errors": []
+                });
+            return;
+        }
+        sendNext();
+    }
+
+    function createEvents(fields, callback) {
+        mutateEvents("events.create", fields, callback);
+    }
+
+    function moveEvents(eventsToMove, dayOffset, callback) {
+        const params = eventsToMove.map(event => Object.assign({
+            "id": event.id
+        }, EventUtils.moveFields(event, dayOffset)));
+        mutateEvents("events.update", params, callback);
+    }
+
+    function deleteEvents(eventsToDelete, callback) {
+        const params = eventsToDelete.map(event => {
+            const fields = {
+                "id": event.id
+            };
+            if ((event.recurringId || "") !== "" || (event.recurrence || []).length > 0)
+                fields.occurrenceStart = new Date(event.start).toISOString();
+            return fields;
+        });
+        mutateEvents("events.delete", params, callback);
     }
 
     function reloadTasks() {

--- a/quickshell/Widgets/DankPopupMenu.qml
+++ b/quickshell/Widgets/DankPopupMenu.qml
@@ -8,8 +8,12 @@ import qs.DankCommon.Widgets
 Popup {
     id: root
 
-    // items: [{ id, label, icon, danger?, enabled? }]
+    // items: [{ id, label, icon, shortcut?, danger?, enabled? }]
+    // Non-action rows use { type: "header", label, subtitle? } or
+    // { type: "separator" }.
     property var items: []
+    property real preferredWidth: 228
+    property int currentIndex: -1
 
     signal triggered(string itemId)
 
@@ -20,15 +24,72 @@ Popup {
         open();
     }
 
-    width: 200
+    function isAction(index) {
+        if (index < 0 || index >= items.length)
+            return false;
+        const item = items[index];
+        return (!item.type || item.type === "action") && item.enabled !== false;
+    }
+
+    function moveCurrent(direction) {
+        if (items.length === 0)
+            return;
+        let next = currentIndex;
+        for (let i = 0; i < items.length; i++) {
+            next = (next + direction + items.length) % items.length;
+            if (isAction(next)) {
+                currentIndex = next;
+                return;
+            }
+        }
+    }
+
+    function triggerCurrent() {
+        if (!isAction(currentIndex))
+            return;
+        const itemId = items[currentIndex].id;
+        close();
+        triggered(itemId);
+    }
+
+    width: preferredWidth
     padding: Theme.spacingXS
     // Outside-press dismissal is armed shortly after opening, otherwise the
     // click that opened the menu can immediately close it. Presses inside the
     // anchor item never auto-close, so the opener can toggle deterministically.
     closePolicy: Popup.CloseOnEscape
 
-    onOpened: armCloseTimer.start()
-    onClosed: closePolicy = Popup.CloseOnEscape
+    focus: true
+    onOpened: {
+        currentIndex = -1;
+        moveCurrent(1);
+        forceActiveFocus();
+        armCloseTimer.start();
+    }
+    onClosed: {
+        closePolicy = Popup.CloseOnEscape;
+        currentIndex = -1;
+    }
+
+    Keys.onPressed: event => {
+        switch (event.key) {
+        case Qt.Key_Up:
+            moveCurrent(-1);
+            break;
+        case Qt.Key_Down:
+            moveCurrent(1);
+            break;
+        case Qt.Key_Return:
+        case Qt.Key_Enter:
+        case Qt.Key_Space:
+            triggerCurrent();
+            break;
+        default:
+            event.accepted = false;
+            return;
+        }
+        event.accepted = true;
+    }
 
     Timer {
         id: armCloseTimer
@@ -55,45 +116,104 @@ Popup {
             }
 
             Rectangle {
+                id: menuRow
                 required property var modelData
-                readonly property bool itemEnabled: modelData.enabled !== false
+                required property int index
+                readonly property string itemType: modelData.type || "action"
+                readonly property bool isAction: itemType === "action"
+                readonly property bool itemEnabled: isAction && modelData.enabled !== false
 
                 width: parent.width
-                height: 36
+                height: itemType === "separator" ? 9 : (itemType === "header" ? 48 : 38)
                 radius: Theme.cornerRadiusSmall
-                color: "transparent"
-                opacity: itemEnabled ? 1 : 0.4
+                color: isAction && root.currentIndex === index ? Theme.primaryBackground : "transparent"
+                opacity: !isAction || itemEnabled ? 1 : 0.4
+
+                Rectangle {
+                    visible: menuRow.itemType === "separator"
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.leftMargin: Theme.spacingS
+                    anchors.rightMargin: Theme.spacingS
+                    height: 1
+                    color: Theme.outlineLight
+                }
+
+                Column {
+                    visible: menuRow.itemType === "header"
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.leftMargin: Theme.spacingM
+                    anchors.rightMargin: Theme.spacingM
+                    spacing: 1
+
+                    StyledText {
+                        text: menuRow.modelData.label || ""
+                        font.pixelSize: Theme.fontSizeMedium
+                        font.weight: Font.Medium
+                        color: Theme.surfaceText
+                        width: parent.width
+                        elide: Text.ElideRight
+                    }
+
+                    StyledText {
+                        visible: text !== ""
+                        text: menuRow.modelData.subtitle || ""
+                        font.pixelSize: Theme.fontSizeSmall
+                        color: Theme.surfaceVariantText
+                        width: parent.width
+                        elide: Text.ElideRight
+                    }
+                }
 
                 Row {
+                    visible: menuRow.isAction
                     anchors.left: parent.left
+                    anchors.right: parent.right
                     anchors.leftMargin: Theme.spacingM
+                    anchors.rightMargin: Theme.spacingM
                     anchors.verticalCenter: parent.verticalCenter
                     spacing: Theme.spacingM
 
                     DankIcon {
-                        visible: !!parent.parent.modelData.icon
-                        name: parent.parent.modelData.icon || ""
+                        visible: !!menuRow.modelData.icon
+                        name: menuRow.modelData.icon || ""
                         size: Theme.iconSize - 6
-                        color: parent.parent.modelData.danger ? Theme.error : Theme.surfaceVariantText
+                        color: menuRow.modelData.danger ? Theme.error : Theme.surfaceVariantText
                         anchors.verticalCenter: parent.verticalCenter
                     }
 
                     StyledText {
-                        text: parent.parent.modelData.label
+                        text: menuRow.modelData.label
                         font.pixelSize: Theme.fontSizeMedium
-                        color: parent.parent.modelData.danger ? Theme.error : Theme.surfaceText
+                        color: menuRow.modelData.danger ? Theme.error : Theme.surfaceText
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: parent.width - (menuRow.modelData.icon ? Theme.iconSize - 6 + Theme.spacingM : 0) - shortcutText.width
+                        elide: Text.ElideRight
+                    }
+
+                    StyledText {
+                        id: shortcutText
+                        visible: text !== ""
+                        text: menuRow.modelData.shortcut || ""
+                        font.pixelSize: Theme.fontSizeSmall
+                        color: Theme.surfaceVariantText
                         anchors.verticalCenter: parent.verticalCenter
                     }
                 }
 
                 StateLayer {
-                    stateColor: parent.modelData.danger ? Theme.error : Theme.primary
+                    visible: menuRow.isAction
+                    stateColor: menuRow.modelData.danger ? Theme.error : Theme.primary
                     cornerRadius: parent.radius
-                    enabled: parent.itemEnabled
-                    disabled: !parent.itemEnabled
+                    enabled: menuRow.itemEnabled
+                    disabled: !menuRow.itemEnabled
                     onClicked: {
+                        root.currentIndex = menuRow.index;
                         root.close();
-                        root.triggered(parent.modelData.id);
+                        root.triggered(menuRow.modelData.id);
                     }
                 }
             }

--- a/quickshell/Widgets/DankPopupMenu.qml
+++ b/quickshell/Widgets/DankPopupMenu.qml
@@ -14,6 +14,9 @@ Popup {
     property var items: []
     property real preferredWidth: 228
     property int currentIndex: -1
+    // Context menus dismiss on any outside press; opener-anchored menus keep
+    // presses on their anchor item inert so the opener can toggle them.
+    property bool dismissOnOutsidePress: false
 
     signal triggered(string itemId)
 
@@ -54,6 +57,7 @@ Popup {
 
     width: preferredWidth
     padding: Theme.spacingS
+    margins: Theme.spacingS
     // Outside-press dismissal is armed shortly after opening, otherwise the
     // click that opened the menu can immediately close it. Presses inside the
     // anchor item never auto-close, so the opener can toggle deterministically.
@@ -74,7 +78,7 @@ Popup {
     Timer {
         id: armCloseTimer
         interval: 100
-        onTriggered: root.closePolicy = Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+        onTriggered: root.closePolicy = Popup.CloseOnEscape | (root.dismissOnOutsidePress ? Popup.CloseOnPressOutside : Popup.CloseOnPressOutsideParent)
     }
 
     background: Rectangle {

--- a/quickshell/Widgets/DankPopupMenu.qml
+++ b/quickshell/Widgets/DankPopupMenu.qml
@@ -53,7 +53,7 @@ Popup {
     }
 
     width: preferredWidth
-    padding: Theme.spacingXS
+    padding: Theme.spacingS
     // Outside-press dismissal is armed shortly after opening, otherwise the
     // click that opened the menu can immediately close it. Presses inside the
     // anchor item never auto-close, so the opener can toggle deterministically.
@@ -63,32 +63,12 @@ Popup {
     onOpened: {
         currentIndex = -1;
         moveCurrent(1);
-        forceActiveFocus();
+        menuFocus.forceActiveFocus();
         armCloseTimer.start();
     }
     onClosed: {
         closePolicy = Popup.CloseOnEscape;
         currentIndex = -1;
-    }
-
-    Keys.onPressed: event => {
-        switch (event.key) {
-        case Qt.Key_Up:
-            moveCurrent(-1);
-            break;
-        case Qt.Key_Down:
-            moveCurrent(1);
-            break;
-        case Qt.Key_Return:
-        case Qt.Key_Enter:
-        case Qt.Key_Space:
-            triggerCurrent();
-            break;
-        default:
-            event.accepted = false;
-            return;
-        }
-        event.accepted = true;
     }
 
     Timer {
@@ -104,116 +84,144 @@ Popup {
         border.color: Theme.outlineMedium
     }
 
-    contentItem: Column {
-        spacing: 1
+    contentItem: FocusScope {
+        id: menuFocus
+        implicitWidth: menuColumn.implicitWidth
+        implicitHeight: menuColumn.implicitHeight
 
-        LayoutMirroring.enabled: I18n.isRtl
-        LayoutMirroring.childrenInherit: true
-
-        Repeater {
-            model: ScriptModel {
-                values: root.items
+        Keys.onPressed: event => {
+            switch (event.key) {
+            case Qt.Key_Up:
+                root.moveCurrent(-1);
+                break;
+            case Qt.Key_Down:
+                root.moveCurrent(1);
+                break;
+            case Qt.Key_Return:
+            case Qt.Key_Enter:
+            case Qt.Key_Space:
+                root.triggerCurrent();
+                break;
+            default:
+                event.accepted = false;
+                return;
             }
+            event.accepted = true;
+        }
 
-            Rectangle {
-                id: menuRow
-                required property var modelData
-                required property int index
-                readonly property string itemType: modelData.type || "action"
-                readonly property bool isAction: itemType === "action"
-                readonly property bool itemEnabled: isAction && modelData.enabled !== false
+        Column {
+            id: menuColumn
+            anchors.fill: parent
+            spacing: 1
 
-                width: parent.width
-                height: itemType === "separator" ? 9 : (itemType === "header" ? 48 : 38)
-                radius: Theme.cornerRadiusSmall
-                color: isAction && root.currentIndex === index ? Theme.primaryBackground : "transparent"
-                opacity: !isAction || itemEnabled ? 1 : 0.4
+            LayoutMirroring.enabled: I18n.isRtl
+            LayoutMirroring.childrenInherit: true
+
+            Repeater {
+                model: ScriptModel {
+                    values: root.items
+                }
 
                 Rectangle {
-                    visible: menuRow.itemType === "separator"
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.leftMargin: Theme.spacingS
-                    anchors.rightMargin: Theme.spacingS
-                    height: 1
-                    color: Theme.outlineLight
-                }
+                    id: menuRow
+                    required property var modelData
+                    required property int index
+                    readonly property string itemType: modelData.type || "action"
+                    readonly property bool isAction: itemType === "action"
+                    readonly property bool itemEnabled: isAction && modelData.enabled !== false
 
-                Column {
-                    visible: menuRow.itemType === "header"
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.leftMargin: Theme.spacingM
-                    anchors.rightMargin: Theme.spacingM
-                    spacing: 1
+                    width: parent.width
+                    height: itemType === "separator" ? 13 : (itemType === "header" ? 52 : 40)
+                    radius: Theme.cornerRadiusSmall
+                    color: isAction && root.currentIndex === index ? Theme.primaryBackground : "transparent"
+                    opacity: !isAction || itemEnabled ? 1 : 0.4
 
-                    StyledText {
-                        text: menuRow.modelData.label || ""
-                        font.pixelSize: Theme.fontSizeMedium
-                        font.weight: Font.Medium
-                        color: Theme.surfaceText
-                        width: parent.width
-                        elide: Text.ElideRight
-                    }
-
-                    StyledText {
-                        visible: text !== ""
-                        text: menuRow.modelData.subtitle || ""
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.surfaceVariantText
-                        width: parent.width
-                        elide: Text.ElideRight
-                    }
-                }
-
-                Row {
-                    visible: menuRow.isAction
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.leftMargin: Theme.spacingM
-                    anchors.rightMargin: Theme.spacingM
-                    anchors.verticalCenter: parent.verticalCenter
-                    spacing: Theme.spacingM
-
-                    DankIcon {
-                        visible: !!menuRow.modelData.icon
-                        name: menuRow.modelData.icon || ""
-                        size: Theme.iconSize - 6
-                        color: menuRow.modelData.danger ? Theme.error : Theme.surfaceVariantText
+                    Rectangle {
+                        visible: menuRow.itemType === "separator"
+                        anchors.left: parent.left
+                        anchors.right: parent.right
                         anchors.verticalCenter: parent.verticalCenter
+                        anchors.leftMargin: Theme.spacingS
+                        anchors.rightMargin: Theme.spacingS
+                        height: 1
+                        color: Theme.outlineLight
                     }
 
-                    StyledText {
-                        text: menuRow.modelData.label
-                        font.pixelSize: Theme.fontSizeMedium
-                        color: menuRow.modelData.danger ? Theme.error : Theme.surfaceText
+                    Column {
+                        visible: menuRow.itemType === "header"
+                        anchors.left: parent.left
+                        anchors.right: parent.right
                         anchors.verticalCenter: parent.verticalCenter
-                        width: parent.width - (menuRow.modelData.icon ? Theme.iconSize - 6 + Theme.spacingM : 0) - shortcutText.width
-                        elide: Text.ElideRight
+                        anchors.leftMargin: Theme.spacingM
+                        anchors.rightMargin: Theme.spacingM
+                        spacing: 1
+
+                        StyledText {
+                            text: menuRow.modelData.label || ""
+                            font.pixelSize: Theme.fontSizeMedium
+                            font.weight: Font.Medium
+                            color: Theme.surfaceText
+                            width: parent.width
+                            elide: Text.ElideRight
+                        }
+
+                        StyledText {
+                            visible: text !== ""
+                            text: menuRow.modelData.subtitle || ""
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceVariantText
+                            width: parent.width
+                            elide: Text.ElideRight
+                        }
                     }
 
-                    StyledText {
-                        id: shortcutText
-                        visible: text !== ""
-                        text: menuRow.modelData.shortcut || ""
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.surfaceVariantText
+                    Row {
+                        visible: menuRow.isAction
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.leftMargin: Theme.spacingM
+                        anchors.rightMargin: Theme.spacingM
                         anchors.verticalCenter: parent.verticalCenter
-                    }
-                }
+                        spacing: Theme.spacingM
 
-                StateLayer {
-                    visible: menuRow.isAction
-                    stateColor: menuRow.modelData.danger ? Theme.error : Theme.primary
-                    cornerRadius: parent.radius
-                    enabled: menuRow.itemEnabled
-                    disabled: !menuRow.itemEnabled
-                    onClicked: {
-                        root.currentIndex = menuRow.index;
-                        root.close();
-                        root.triggered(menuRow.modelData.id);
+                        DankIcon {
+                            visible: !!menuRow.modelData.icon
+                            name: menuRow.modelData.icon || ""
+                            size: Theme.iconSize - 6
+                            color: menuRow.modelData.danger ? Theme.error : Theme.surfaceVariantText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        StyledText {
+                            text: menuRow.modelData.label
+                            font.pixelSize: Theme.fontSizeMedium
+                            color: menuRow.modelData.danger ? Theme.error : Theme.surfaceText
+                            anchors.verticalCenter: parent.verticalCenter
+                            width: parent.width - (menuRow.modelData.icon ? Theme.iconSize - 6 + Theme.spacingM : 0) - (shortcutText.visible ? shortcutText.width + Theme.spacingM : 0)
+                            elide: Text.ElideRight
+                        }
+
+                        StyledText {
+                            id: shortcutText
+                            visible: text !== ""
+                            text: menuRow.modelData.shortcut || ""
+                            font.pixelSize: Theme.fontSizeSmall
+                            color: Theme.surfaceVariantText
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+
+                    StateLayer {
+                        visible: menuRow.isAction
+                        stateColor: menuRow.modelData.danger ? Theme.error : Theme.primary
+                        cornerRadius: parent.radius
+                        enabled: menuRow.itemEnabled
+                        disabled: !menuRow.itemEnabled
+                        onClicked: {
+                            root.currentIndex = menuRow.index;
+                            root.close();
+                            root.triggered(menuRow.modelData.id);
+                        }
                     }
                 }
             }

--- a/quickshell/Widgets/EventContextMenu.qml
+++ b/quickshell/Widgets/EventContextMenu.qml
@@ -1,0 +1,196 @@
+import QtQuick
+import qs.Common
+import qs.Services
+import qs.Widgets
+import "../Common/EventUtils.js" as EventUtils
+
+Item {
+    id: root
+
+    property var controller: null
+    property var actionEvent: null
+    property date targetDay: new Date()
+    property date selectedDay: new Date()
+
+    readonly property bool eventMode: actionEvent !== null
+    readonly property int selectionCount: controller ? controller.count : 0
+
+    signal openRequested(var event)
+    signal createRequested(date day)
+    signal deleteRequested(var event)
+
+    visible: false
+    width: 0
+    height: 0
+
+    function showForEvent(event, anchorItem, x, y) {
+        actionEvent = event;
+        targetDay = new Date(event.start);
+        controller.ensureSelected(event);
+        menu.show(anchorItem, x, y);
+    }
+
+    function showForDay(day, anchorItem, x, y) {
+        actionEvent = null;
+        targetDay = new Date(day);
+        menu.show(anchorItem, x, y);
+    }
+
+    function countLabel(action, count) {
+        if (count === 1)
+            return action;
+        return action + " " + count + " " + I18n.tr("events", "plural event noun in context menu actions");
+    }
+
+    function eventSubtitle(event) {
+        const when = event.allDay ? I18n.tr("All day", "all-day marker in event context menu") : SettingsData.formatTime(event.start) + " – " + SettingsData.formatTime(event.end);
+        return event.calendar ? when + " · " + event.calendar : when;
+    }
+
+    function menuItems() {
+        const items = [];
+        if (!eventMode) {
+            items.push({
+                type: "header",
+                label: Qt.formatDate(targetDay, "dddd, MMMM d"),
+                subtitle: I18n.tr("Day actions", "subtitle for a calendar day context menu")
+            });
+            items.push({
+                id: "create",
+                label: I18n.tr("New event", "calendar day context menu action"),
+                icon: "add"
+            });
+            items.push({
+                id: "paste",
+                label: controller && controller.clipboardCount === 1 ? I18n.tr("Paste 1 event", "calendar day context menu paste action for one event") : I18n.tr("Paste %1 events", "calendar day context menu paste action; %1 is event count").arg(controller ? controller.clipboardCount : 0),
+                icon: "content_paste",
+                shortcut: "Ctrl+V",
+                enabled: controller && controller.clipboardCount > 0 && !controller.busy
+            });
+            const dayCount = DankCalService.eventsForDay(targetDay).length;
+            items.push({
+                id: "selectDay",
+                label: dayCount === 1 ? I18n.tr("Select event", "calendar day context menu action for one event") : I18n.tr("Select all %1 events", "calendar day context menu selection action; %1 is event count").arg(dayCount),
+                icon: "select_all",
+                enabled: dayCount > 0
+            });
+            return items;
+        }
+
+        if (selectionCount === 1) {
+            items.push({
+                type: "header",
+                label: actionEvent.title,
+                subtitle: eventSubtitle(actionEvent)
+            });
+            items.push({
+                id: "open",
+                label: I18n.tr("Open event", "event context menu action"),
+                icon: "open_in_new",
+                shortcut: "Enter"
+            });
+        } else {
+            items.push({
+                type: "header",
+                label: I18n.tr("%1 events selected", "event context menu selection summary; %1 is event count").arg(selectionCount),
+                subtitle: I18n.tr("Actions apply to the whole selection", "event context menu multi-selection hint")
+            });
+        }
+
+        items.push({
+            type: "separator"
+        });
+        items.push({
+            id: "copy",
+            label: selectionCount === 1 ? I18n.tr("Copy event", "event context menu copy action for one event") : I18n.tr("Copy %1 events", "event context menu copy action; %1 is event count").arg(selectionCount),
+            icon: "content_copy",
+            shortcut: "Ctrl+C",
+            enabled: !controller.busy
+        });
+        items.push({
+            id: "duplicate",
+            label: countLabel(I18n.tr("Duplicate", "event context menu duplicate action"), selectionCount),
+            icon: "file_copy",
+            shortcut: "Ctrl+D",
+            enabled: !controller.busy
+        });
+        items.push({
+            id: "tomorrow",
+            label: countLabel(I18n.tr("Repeat tomorrow", "event context menu quick repeat action"), selectionCount),
+            icon: "update",
+            enabled: !controller.busy
+        });
+        items.push({
+            id: "nextWeek",
+            label: countLabel(I18n.tr("Repeat next week", "event context menu quick repeat action"), selectionCount),
+            icon: "event_repeat",
+            enabled: !controller.busy
+        });
+        items.push({
+            id: "moveSelected",
+            label: I18n.tr("Move to selected day", "event context menu move action"),
+            icon: "drive_file_move",
+            enabled: controller.allWritable(actionEvent) && EventUtils.daysBetween(actionEvent.start, selectedDay) !== 0 && !controller.busy
+        });
+        if (controller.clipboardCount > 0) {
+            items.push({
+                id: "paste",
+                label: controller.clipboardCount === 1 ? I18n.tr("Paste 1 event here", "event context menu paste action for one event") : I18n.tr("Paste %1 events here", "event context menu paste action; %1 is event count").arg(controller.clipboardCount),
+                icon: "content_paste",
+                shortcut: "Ctrl+V",
+                enabled: !controller.busy
+            });
+        }
+        items.push({
+            type: "separator"
+        });
+        items.push({
+            id: "delete",
+            label: selectionCount === 1 ? I18n.tr("Delete event…", "event context menu delete action for one event") : I18n.tr("Delete %1 events…", "event context menu delete action; %1 is event count").arg(selectionCount),
+            icon: "delete_outline",
+            danger: true,
+            enabled: controller.allWritable(actionEvent) && !controller.busy
+        });
+        return items;
+    }
+
+    DankPopupMenu {
+        id: menu
+        preferredWidth: 264
+        items: root.menuItems()
+        onTriggered: itemId => {
+            switch (itemId) {
+            case "open":
+                root.openRequested(root.actionEvent);
+                break;
+            case "create":
+                root.createRequested(root.targetDay);
+                break;
+            case "selectDay":
+                root.controller.selectDay(root.targetDay);
+                break;
+            case "copy":
+                root.controller.copy(root.actionEvent);
+                break;
+            case "duplicate":
+                root.controller.duplicate(0, root.actionEvent);
+                break;
+            case "tomorrow":
+                root.controller.duplicate(1, root.actionEvent);
+                break;
+            case "nextWeek":
+                root.controller.duplicate(7, root.actionEvent);
+                break;
+            case "moveSelected":
+                root.controller.moveTo(root.actionEvent, root.selectedDay);
+                break;
+            case "paste":
+                root.controller.paste(root.targetDay);
+                break;
+            case "delete":
+                root.deleteRequested(root.actionEvent);
+                break;
+            }
+        }
+    }
+}

--- a/quickshell/Widgets/EventContextMenu.qml
+++ b/quickshell/Widgets/EventContextMenu.qml
@@ -36,15 +36,18 @@ Item {
         menu.show(anchorItem, x, y);
     }
 
-    function countLabel(action, count) {
-        if (count === 1)
-            return action;
-        return action + " " + count + " " + I18n.tr("events", "plural event noun in context menu actions");
-    }
-
     function eventSubtitle(event) {
         const when = event.allDay ? I18n.tr("All day", "all-day marker in event context menu") : SettingsData.formatTime(event.start) + " – " + SettingsData.formatTime(event.end);
         return event.calendar ? when + " · " + event.calendar : when;
+    }
+
+    function pasteLabel(includeHere) {
+        const count = controller ? controller.clipboardCount : 0;
+        if (controller && controller.clipboardIsCut)
+            return count === 1 ? I18n.tr("Move 1 event here", "calendar context menu cut-paste action for one event") : I18n.tr("Move %1 events here", "calendar context menu cut-paste action; %1 is event count").arg(count);
+        if (includeHere)
+            return count === 1 ? I18n.tr("Paste 1 event here", "event context menu paste action for one event") : I18n.tr("Paste %1 events here", "event context menu paste action; %1 is event count").arg(count);
+        return count === 1 ? I18n.tr("Paste 1 event", "calendar day context menu paste action for one event") : I18n.tr("Paste %1 events", "calendar day context menu paste action; %1 is event count").arg(count);
     }
 
     function menuItems() {
@@ -62,7 +65,7 @@ Item {
             });
             items.push({
                 id: "paste",
-                label: controller && controller.clipboardCount === 1 ? I18n.tr("Paste 1 event", "calendar day context menu paste action for one event") : I18n.tr("Paste %1 events", "calendar day context menu paste action; %1 is event count").arg(controller ? controller.clipboardCount : 0),
+                label: pasteLabel(false),
                 icon: "content_paste",
                 shortcut: "Ctrl+V",
                 enabled: controller && controller.clipboardCount > 0 && !controller.busy
@@ -108,21 +111,28 @@ Item {
             enabled: !controller.busy
         });
         items.push({
+            id: "cut",
+            label: selectionCount === 1 ? I18n.tr("Cut event", "event context menu cut action for one event") : I18n.tr("Cut %1 events", "event context menu cut action; %1 is event count").arg(selectionCount),
+            icon: "content_cut",
+            shortcut: "Ctrl+X",
+            enabled: controller.allWritable(actionEvent) && !controller.busy
+        });
+        items.push({
             id: "duplicate",
-            label: countLabel(I18n.tr("Duplicate", "event context menu duplicate action"), selectionCount),
+            label: selectionCount === 1 ? I18n.tr("Duplicate", "event context menu duplicate action for one event") : I18n.tr("Duplicate %1 events", "event context menu duplicate action; %1 is event count").arg(selectionCount),
             icon: "file_copy",
             shortcut: "Ctrl+D",
             enabled: !controller.busy
         });
         items.push({
             id: "tomorrow",
-            label: countLabel(I18n.tr("Repeat tomorrow", "event context menu quick repeat action"), selectionCount),
+            label: selectionCount === 1 ? I18n.tr("Repeat tomorrow", "event context menu quick repeat action for one event") : I18n.tr("Repeat %1 events tomorrow", "event context menu quick repeat action; %1 is event count").arg(selectionCount),
             icon: "update",
             enabled: !controller.busy
         });
         items.push({
             id: "nextWeek",
-            label: countLabel(I18n.tr("Repeat next week", "event context menu quick repeat action"), selectionCount),
+            label: selectionCount === 1 ? I18n.tr("Repeat next week", "event context menu quick repeat action for one event") : I18n.tr("Repeat %1 events next week", "event context menu quick repeat action; %1 is event count").arg(selectionCount),
             icon: "event_repeat",
             enabled: !controller.busy
         });
@@ -135,7 +145,7 @@ Item {
         if (controller.clipboardCount > 0) {
             items.push({
                 id: "paste",
-                label: controller.clipboardCount === 1 ? I18n.tr("Paste 1 event here", "event context menu paste action for one event") : I18n.tr("Paste %1 events here", "event context menu paste action; %1 is event count").arg(controller.clipboardCount),
+                label: pasteLabel(true),
                 icon: "content_paste",
                 shortcut: "Ctrl+V",
                 enabled: !controller.busy
@@ -171,6 +181,9 @@ Item {
                 break;
             case "copy":
                 root.controller.copy(root.actionEvent);
+                break;
+            case "cut":
+                root.controller.cut(root.actionEvent);
                 break;
             case "duplicate":
                 root.controller.duplicate(0, root.actionEvent);

--- a/quickshell/Widgets/EventContextMenu.qml
+++ b/quickshell/Widgets/EventContextMenu.qml
@@ -18,6 +18,7 @@ Item {
     signal openRequested(var event)
     signal createRequested(date day)
     signal deleteRequested(var event)
+    signal moveRequested(var event, date day)
 
     visible: false
     width: 0
@@ -167,6 +168,7 @@ Item {
     DankPopupMenu {
         id: menu
         preferredWidth: 264
+        dismissOnOutsidePress: true
         items: root.menuItems()
         onTriggered: itemId => {
             switch (itemId) {
@@ -195,7 +197,7 @@ Item {
                 root.controller.duplicate(7, root.actionEvent);
                 break;
             case "moveSelected":
-                root.controller.moveTo(root.actionEvent, root.selectedDay);
+                root.moveRequested(root.actionEvent, root.selectedDay);
                 break;
             case "paste":
                 root.controller.paste(root.targetDay);

--- a/quickshell/Widgets/EventDragGhost.qml
+++ b/quickshell/Widgets/EventDragGhost.qml
@@ -1,0 +1,37 @@
+import QtQuick
+import qs.Common
+import qs.Services
+import qs.Widgets
+
+Rectangle {
+    id: root
+
+    property bool dragging: false
+    property var draggedEvent: null
+    property point dragPosition: Qt.point(0, 0)
+    property var selectedKeys: []
+
+    readonly property int groupCount: draggedEvent && selectedKeys.length > 1 && selectedKeys.indexOf(DankCalService.eventKey(draggedEvent)) !== -1 ? selectedKeys.length : 0
+
+    visible: dragging && draggedEvent !== null
+    x: Math.min(parent.width - width - Theme.spacingS, Math.max(Theme.spacingS, dragPosition.x + 12))
+    y: Math.min(parent.height - height - Theme.spacingS, Math.max(Theme.spacingS, dragPosition.y + 12))
+    width: Math.min(220, dragLabel.implicitWidth + Theme.spacingL * 2)
+    height: 34
+    radius: Theme.cornerRadiusSmall
+    color: Theme.surfaceContainerHigh
+    border.color: Theme.primary
+    border.width: 2
+    z: 100
+
+    StyledText {
+        id: dragLabel
+        anchors.centerIn: parent
+        text: root.groupCount > 0 ? I18n.tr("Move %1 events", "event drag preview label; %1 is event count").arg(root.groupCount) : (root.draggedEvent ? root.draggedEvent.title : "")
+        font.pixelSize: Theme.fontSizeSmall
+        font.weight: Font.Medium
+        color: Theme.surfaceText
+        elide: Text.ElideRight
+        width: Math.min(196, implicitWidth)
+    }
+}

--- a/quickshell/Widgets/EventMouseArea.qml
+++ b/quickshell/Widgets/EventMouseArea.qml
@@ -1,0 +1,75 @@
+import QtQuick
+
+MouseArea {
+    id: root
+
+    property var eventData: null
+    property bool dragEnabled: false
+    property real dragThreshold: 8
+    property real pressX: 0
+    property real pressY: 0
+    property bool eventDragging: false
+    property bool suppressActivation: false
+
+    signal activated(var event, int modifiers)
+    signal contextRequested(var event, var anchorItem, real x, real y)
+    signal dragPressed
+    signal dragStarted(var event, var pointerItem, real x, real y)
+    signal dragMoved(var event, var pointerItem, real x, real y)
+    signal dropped(var event, var pointerItem, real x, real y)
+    signal dragReleased
+
+    acceptedButtons: Qt.LeftButton | Qt.RightButton
+    hoverEnabled: true
+    cursorShape: eventDragging ? Qt.DragMoveCursor : Qt.PointingHandCursor
+
+    onPressed: mouse => {
+        if (mouse.button !== Qt.LeftButton || !dragEnabled)
+            return;
+        pressX = mouse.x;
+        pressY = mouse.y;
+        suppressActivation = false;
+        dragPressed();
+    }
+
+    onPositionChanged: mouse => {
+        if (!dragEnabled || !(mouse.buttons & Qt.LeftButton))
+            return;
+        if (!eventDragging) {
+            const dx = mouse.x - pressX;
+            const dy = mouse.y - pressY;
+            if (Math.sqrt(dx * dx + dy * dy) < dragThreshold)
+                return;
+            eventDragging = true;
+            suppressActivation = true;
+            dragStarted(eventData, root, mouse.x, mouse.y);
+        }
+        dragMoved(eventData, root, mouse.x, mouse.y);
+    }
+
+    onReleased: mouse => {
+        if (eventDragging)
+            dropped(eventData, root, mouse.x, mouse.y);
+        eventDragging = false;
+        dragReleased();
+    }
+
+    onCanceled: {
+        eventDragging = false;
+        suppressActivation = false;
+        dragReleased();
+    }
+
+    onClicked: mouse => {
+        mouse.accepted = true;
+        if (suppressActivation) {
+            suppressActivation = false;
+            return;
+        }
+        if (mouse.button === Qt.RightButton) {
+            contextRequested(eventData, parent, mouse.x, mouse.y);
+            return;
+        }
+        activated(eventData, mouse.modifiers);
+    }
+}

--- a/quickshell/Widgets/EventSelectionBar.qml
+++ b/quickshell/Widgets/EventSelectionBar.qml
@@ -1,0 +1,167 @@
+import QtQuick
+import qs.Common
+import qs.Widgets
+import qs.DankCommon.Widgets
+
+Item {
+    id: root
+
+    property var controller: null
+
+    signal deleteRequested
+
+    readonly property var actions: [
+        {
+            id: "copy",
+            label: I18n.tr("Copy", "multi-event action shelf label"),
+            icon: "content_copy"
+        },
+        {
+            id: "duplicate",
+            label: I18n.tr("Again", "multi-event action shelf duplicate label"),
+            icon: "file_copy"
+        },
+        {
+            id: "tomorrow",
+            label: I18n.tr("+1 day", "multi-event action shelf repeat tomorrow label"),
+            icon: "update"
+        },
+        {
+            id: "week",
+            label: I18n.tr("+1 week", "multi-event action shelf repeat next week label"),
+            icon: "event_repeat"
+        },
+        {
+            id: "delete",
+            label: I18n.tr("Delete", "multi-event action shelf label"),
+            icon: "delete_outline",
+            danger: true
+        },
+        {
+            id: "clear",
+            label: I18n.tr("Clear", "multi-event action shelf clear selection label"),
+            icon: "close"
+        }
+    ]
+
+    function run(actionId) {
+        switch (actionId) {
+        case "copy":
+            controller.copy();
+            break;
+        case "duplicate":
+            controller.duplicate(0);
+            break;
+        case "tomorrow":
+            controller.duplicate(1);
+            break;
+        case "week":
+            controller.duplicate(7);
+            break;
+        case "delete":
+            deleteRequested();
+            break;
+        case "clear":
+            controller.clear();
+            break;
+        }
+    }
+
+    visible: controller && controller.count > 1
+    implicitWidth: selectionLabel.width + actionRow.width + Theme.spacingL * 2 + Theme.spacingM
+    implicitHeight: 54
+    opacity: visible ? 1 : 0
+    scale: visible ? 1 : 0.96
+
+    Behavior on opacity {
+        NumberAnimation {
+            duration: Theme.shortDuration
+            easing.type: Theme.standardEasing
+        }
+    }
+
+    Behavior on scale {
+        NumberAnimation {
+            duration: Theme.shortDuration
+            easing.type: Theme.standardEasing
+        }
+    }
+
+    StyledRect {
+        anchors.fill: parent
+        color: Theme.surfaceContainerHigh
+        radius: Theme.cornerRadiusLarge
+        border.color: Theme.primary
+        border.width: 1
+    }
+
+    Row {
+        anchors.centerIn: parent
+        spacing: Theme.spacingM
+
+        Row {
+            id: selectionLabel
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Theme.spacingS
+
+            DankIcon {
+                name: "select_all"
+                size: Theme.iconSize - 2
+                color: Theme.primary
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            StyledText {
+                text: I18n.tr("%1 selected", "multi-event action shelf selection count; %1 is event count").arg(root.controller ? root.controller.count : 0)
+                font.pixelSize: Theme.fontSizeMedium
+                font.weight: Font.Medium
+                color: Theme.surfaceText
+                anchors.verticalCenter: parent.verticalCenter
+            }
+        }
+
+        Row {
+            id: actionRow
+            spacing: 2
+
+            Repeater {
+                model: ScriptModel {
+                    values: root.actions
+                }
+
+                Item {
+                    id: action
+                    required property var modelData
+                    width: 52
+                    height: 44
+
+                    Column {
+                        anchors.centerIn: parent
+                        spacing: 0
+
+                        DankIcon {
+                            name: action.modelData.icon
+                            size: Theme.iconSize - 4
+                            color: action.modelData.danger ? Theme.error : Theme.surfaceVariantText
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+
+                        StyledText {
+                            text: action.modelData.label
+                            font.pixelSize: 9
+                            color: action.modelData.danger ? Theme.error : Theme.surfaceVariantText
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+                    }
+
+                    StateLayer {
+                        stateColor: action.modelData.danger ? Theme.error : Theme.primary
+                        cornerRadius: Theme.cornerRadiusSmall
+                        disabled: root.controller ? root.controller.busy : true
+                        onClicked: root.run(action.modelData.id)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/quickshell/Widgets/EventSelectionBar.qml
+++ b/quickshell/Widgets/EventSelectionBar.qml
@@ -24,7 +24,7 @@ Item {
         },
         {
             id: "duplicate",
-            label: I18n.tr("Again", "multi-event action shelf duplicate label"),
+            label: I18n.tr("Duplicate", "multi-event action shelf duplicate label"),
             icon: "file_copy"
         },
         {
@@ -76,11 +76,13 @@ Item {
         }
     }
 
-    visible: controller && controller.count > 1
+    readonly property bool shown: controller !== null && controller.count > 1
+
+    visible: opacity > 0
     implicitWidth: selectionLabel.width + actionRow.width + Theme.spacingL * 2 + Theme.spacingM
     implicitHeight: 54
-    opacity: visible ? 1 : 0
-    scale: visible ? 1 : 0.96
+    opacity: shown ? 1 : 0
+    scale: shown ? 1 : 0.96
 
     Behavior on opacity {
         NumberAnimation {
@@ -141,7 +143,7 @@ Item {
                 Item {
                     id: action
                     required property var modelData
-                    width: 48
+                    width: Math.max(48, actionLabel.implicitWidth + Theme.spacingS * 2)
                     height: 44
 
                     Column {
@@ -156,8 +158,9 @@ Item {
                         }
 
                         StyledText {
+                            id: actionLabel
                             text: action.modelData.label
-                            font.pixelSize: 9
+                            font.pixelSize: Theme.fontSizeSmall - 2
                             color: action.modelData.danger ? Theme.error : Theme.surfaceVariantText
                             anchors.horizontalCenter: parent.horizontalCenter
                         }

--- a/quickshell/Widgets/EventSelectionBar.qml
+++ b/quickshell/Widgets/EventSelectionBar.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import Quickshell
 import qs.Common
 import qs.Widgets
 import qs.DankCommon.Widgets
@@ -15,6 +16,11 @@ Item {
             id: "copy",
             label: I18n.tr("Copy", "multi-event action shelf label"),
             icon: "content_copy"
+        },
+        {
+            id: "cut",
+            label: I18n.tr("Cut", "multi-event action shelf label"),
+            icon: "content_cut"
         },
         {
             id: "duplicate",
@@ -48,6 +54,9 @@ Item {
         switch (actionId) {
         case "copy":
             controller.copy();
+            break;
+        case "cut":
+            controller.cut();
             break;
         case "duplicate":
             controller.duplicate(0);
@@ -132,7 +141,7 @@ Item {
                 Item {
                     id: action
                     required property var modelData
-                    width: 52
+                    width: 48
                     height: 44
 
                     Column {

--- a/quickshell/Widgets/EventSelectionModel.qml
+++ b/quickshell/Widgets/EventSelectionModel.qml
@@ -15,6 +15,7 @@ Item {
     readonly property bool hasSelection: count > 0
     readonly property var clipboardEvents: EventUtils.clipboardEvents(Quickshell.clipboardText)
     readonly property int clipboardCount: clipboardEvents.length
+    readonly property bool clipboardIsCut: clipboardCount > 0 && clipboardEvents.every(event => event._dankCut)
 
     visible: false
     width: 0
@@ -139,8 +140,20 @@ Item {
         const selected = events(fallback);
         if (selected.length === 0)
             return;
-        Quickshell.clipboardText = EventUtils.clipboardText(selected);
+        Quickshell.clipboardText = EventUtils.clipboardText(selected, false);
         ToastService.info(selected.length === 1 ? I18n.tr("Copied 1 event", "clipboard confirmation for one event") : I18n.tr("Copied %1 events", "clipboard confirmation for multiple events; %1 is event count").arg(selected.length));
+    }
+
+    function cut(fallback) {
+        if (fallback)
+            ensureSelected(fallback);
+        const selected = events(fallback);
+        if (!allWritable(fallback)) {
+            ToastService.info(I18n.tr("Read-only events can't be cut", "event cut error for a read-only calendar"));
+            return;
+        }
+        Quickshell.clipboardText = EventUtils.clipboardText(selected, true);
+        ToastService.info(selected.length === 1 ? I18n.tr("Cut 1 event", "clipboard confirmation for one event") : I18n.tr("Cut %1 events", "clipboard confirmation for multiple events; %1 is event count").arg(selected.length));
     }
 
     function paste(targetDay) {
@@ -153,12 +166,26 @@ Item {
             return;
         }
         const fields = EventUtils.pasteFields(copied, targetDay, fallbackId);
-        for (let i = 0; i < fields.length; i++)
+        const cutSources = [];
+        for (let i = 0; i < fields.length; i++) {
+            if (fields[i]._dankCut)
+                cutSources.push(fields[i]._dankCut);
+            delete fields[i]._dankCut;
             fields[i].calendarId = writableCalendarId(fields[i].calendarId);
+        }
         busy = true;
         DankCalService.createEvents(fields, response => {
-            root.finishOperation(I18n.tr("pasted", "past-tense event action used in a result message"), fields.length, response);
-            root.clear();
+            if (response.error || cutSources.length !== fields.length) {
+                root.finishOperation(I18n.tr("pasted", "past-tense event action used in a result message"), fields.length, response);
+                root.clear();
+                return;
+            }
+            DankCalService.deleteEvents(cutSources, deleteResponse => {
+                root.finishOperation(I18n.tr("moved", "past-tense event action used in a result message"), fields.length, deleteResponse);
+                if (!deleteResponse.error)
+                    Quickshell.clipboardText = EventUtils.clipboardText(cutSources, false);
+                root.clear();
+            });
         });
     }
 

--- a/quickshell/Widgets/EventSelectionModel.qml
+++ b/quickshell/Widgets/EventSelectionModel.qml
@@ -124,14 +124,31 @@ Item {
         return fallback ? fallback.id : "";
     }
 
-    function finishOperation(verb, total, response) {
-        busy = false;
-        const completed = (response.results || []).length;
-        if (response.error) {
-            ToastService.info(I18n.tr("%1 of %2 events %3", "partial batch event action result; %1 completed count, %2 total count, %3 action verb").arg(completed).arg(total).arg(verb));
-            return;
+    function operationToast(action, completed, total) {
+        switch (action) {
+        case "paste":
+            if (completed !== total)
+                return I18n.tr("Pasted %1 of %2 events", "toast when only some events pasted; %1 is completed count, %2 is total count").arg(completed).arg(total);
+            return total === 1 ? I18n.tr("Pasted 1 event", "toast after pasting one event") : I18n.tr("Pasted %1 events", "toast after pasting multiple events; %1 is event count").arg(total);
+        case "move":
+            if (completed !== total)
+                return I18n.tr("Moved %1 of %2 events", "toast when only some events moved; %1 is completed count, %2 is total count").arg(completed).arg(total);
+            return total === 1 ? I18n.tr("Moved 1 event", "toast after moving one event") : I18n.tr("Moved %1 events", "toast after moving multiple events; %1 is event count").arg(total);
+        case "create":
+            if (completed !== total)
+                return I18n.tr("Created %1 of %2 events", "toast when only some events created; %1 is completed count, %2 is total count").arg(completed).arg(total);
+            return total === 1 ? I18n.tr("Created 1 event", "toast after creating one event") : I18n.tr("Created %1 events", "toast after creating multiple events; %1 is event count").arg(total);
+        case "delete":
+            if (completed !== total)
+                return I18n.tr("Deleted %1 of %2 events", "toast when only some events deleted; %1 is completed count, %2 is total count").arg(completed).arg(total);
+            return total === 1 ? I18n.tr("Deleted 1 event", "toast after deleting one event") : I18n.tr("Deleted %1 events", "toast after deleting multiple events; %1 is event count").arg(total);
         }
-        ToastService.info(total === 1 ? I18n.tr("1 event %1", "single event action result; %1 is an action verb").arg(verb) : I18n.tr("%1 events %2", "multiple event action result; %1 is event count, %2 is an action verb").arg(total).arg(verb));
+        return "";
+    }
+
+    function finishOperation(action, total, response) {
+        busy = false;
+        ToastService.info(operationToast(action, (response.results || []).length, total));
     }
 
     function copy(fallback) {
@@ -148,6 +165,8 @@ Item {
         if (fallback)
             ensureSelected(fallback);
         const selected = events(fallback);
+        if (selected.length === 0)
+            return;
         if (!allWritable(fallback)) {
             ToastService.info(I18n.tr("Read-only events can't be cut", "event cut error for a read-only calendar"));
             return;
@@ -176,14 +195,14 @@ Item {
         busy = true;
         DankCalService.createEvents(fields, response => {
             if (response.error || cutSources.length !== fields.length) {
-                root.finishOperation(I18n.tr("pasted", "past-tense event action used in a result message"), fields.length, response);
+                root.finishOperation("paste", fields.length, response);
                 root.clear();
                 return;
             }
             DankCalService.deleteEvents(cutSources, deleteResponse => {
-                root.finishOperation(I18n.tr("moved", "past-tense event action used in a result message"), fields.length, deleteResponse);
+                root.finishOperation("move", fields.length, deleteResponse);
                 if (!deleteResponse.error)
-                    Quickshell.clipboardText = EventUtils.clipboardText(cutSources, false);
+                    Quickshell.clipboardText = EventUtils.clipboardTextFromFields(fields);
                 root.clear();
             });
         });
@@ -206,7 +225,7 @@ Item {
             return;
         }
         busy = true;
-        DankCalService.createEvents(fields, response => root.finishOperation(I18n.tr("created", "past-tense event action used in a result message"), fields.length, response));
+        DankCalService.createEvents(fields, response => root.finishOperation("create", fields.length, response));
     }
 
     function moveTo(anchorEvent, targetDay) {
@@ -223,7 +242,7 @@ Item {
             return;
         busy = true;
         DankCalService.moveEvents(selected, offset, response => {
-            root.finishOperation(I18n.tr("moved", "past-tense event action used in a result message"), selected.length, response);
+            root.finishOperation("move", selected.length, response);
             root.clear();
         });
     }
@@ -234,13 +253,15 @@ Item {
         if (fallback)
             ensureSelected(fallback);
         const selected = events(fallback);
+        if (selected.length === 0)
+            return;
         if (!allWritable(fallback)) {
             ToastService.info(I18n.tr("Read-only events can't be deleted", "event delete error for a read-only calendar"));
             return;
         }
         busy = true;
         DankCalService.deleteEvents(selected, response => {
-            root.finishOperation(I18n.tr("deleted", "past-tense event action used in a result message"), selected.length, response);
+            root.finishOperation("delete", selected.length, response);
             root.clear();
         });
     }

--- a/quickshell/Widgets/EventSelectionModel.qml
+++ b/quickshell/Widgets/EventSelectionModel.qml
@@ -1,0 +1,127 @@
+import QtQuick
+import qs.Services
+
+Item {
+    id: root
+
+    property var selectedKeys: []
+    property string anchorKey: ""
+    property bool busy: false
+
+    readonly property int count: selectedKeys.length
+    readonly property bool hasSelection: count > 0
+
+    visible: false
+    width: 0
+    height: 0
+
+    function contains(event) {
+        return selectedKeys.indexOf(DankCalService.eventKey(event)) !== -1;
+    }
+
+    function clear() {
+        selectedKeys = [];
+        anchorKey = "";
+    }
+
+    function replace(events) {
+        selectedKeys = events.map(event => DankCalService.eventKey(event));
+        anchorKey = selectedKeys.length > 0 ? selectedKeys[selectedKeys.length - 1] : "";
+    }
+
+    function ensureSelected(event) {
+        if (contains(event))
+            return;
+        replace([event]);
+    }
+
+    function selectRange(event, additive) {
+        const events = DankCalService.visibleEvents();
+        const targetKey = DankCalService.eventKey(event);
+        let anchorIndex = -1;
+        let targetIndex = -1;
+        for (let i = 0; i < events.length; i++) {
+            const key = DankCalService.eventKey(events[i]);
+            if (key === anchorKey)
+                anchorIndex = i;
+            if (key === targetKey)
+                targetIndex = i;
+        }
+        if (anchorIndex < 0 || targetIndex < 0) {
+            replace([event]);
+            return;
+        }
+
+        const start = Math.min(anchorIndex, targetIndex);
+        const end = Math.max(anchorIndex, targetIndex);
+        const rangeKeys = events.slice(start, end + 1).map(item => DankCalService.eventKey(item));
+        if (!additive) {
+            selectedKeys = rangeKeys;
+            return;
+        }
+
+        const merged = selectedKeys.slice();
+        for (let i = 0; i < rangeKeys.length; i++) {
+            if (merged.indexOf(rangeKeys[i]) === -1)
+                merged.push(rangeKeys[i]);
+        }
+        selectedKeys = merged;
+    }
+
+    function select(event, modifiers) {
+        const toggle = (modifiers & (Qt.ControlModifier | Qt.MetaModifier)) !== 0;
+        const extend = (modifiers & Qt.ShiftModifier) !== 0;
+        const key = DankCalService.eventKey(event);
+
+        if (extend && anchorKey !== "") {
+            selectRange(event, toggle);
+            return;
+        }
+        if (toggle) {
+            const keys = selectedKeys.slice();
+            const index = keys.indexOf(key);
+            if (index === -1)
+                keys.push(key);
+            else
+                keys.splice(index, 1);
+            selectedKeys = keys;
+            anchorKey = key;
+            return;
+        }
+        selectedKeys = [key];
+        anchorKey = key;
+    }
+
+    function selectDay(day) {
+        replace(DankCalService.eventsForDay(day));
+    }
+
+    function events(fallback) {
+        const resolved = DankCalService.eventsByKeys(selectedKeys);
+        if (resolved.length > 0)
+            return resolved;
+        return fallback ? [fallback] : [];
+    }
+
+    function allWritable(fallback) {
+        const selected = events(fallback);
+        return selected.length > 0 && selected.every(event => !event.readOnly);
+    }
+
+    Connections {
+        target: DankCalService
+        function onEventsUpdated() {
+            if (root.selectedKeys.length === 0)
+                return;
+            const available = {};
+            const events = DankCalService.visibleEvents();
+            for (let i = 0; i < events.length; i++)
+                available[DankCalService.eventKey(events[i])] = true;
+            const next = root.selectedKeys.filter(key => available[key]);
+            if (next.length !== root.selectedKeys.length)
+                root.selectedKeys = next;
+            if (root.anchorKey !== "" && !available[root.anchorKey])
+                root.anchorKey = next.length > 0 ? next[next.length - 1] : "";
+        }
+    }
+}

--- a/quickshell/Widgets/EventSelectionModel.qml
+++ b/quickshell/Widgets/EventSelectionModel.qml
@@ -1,5 +1,8 @@
 import QtQuick
+import Quickshell
+import qs.Common
 import qs.Services
+import "../Common/EventUtils.js" as EventUtils
 
 Item {
     id: root
@@ -10,6 +13,8 @@ Item {
 
     readonly property int count: selectedKeys.length
     readonly property bool hasSelection: count > 0
+    readonly property var clipboardEvents: EventUtils.clipboardEvents(Quickshell.clipboardText)
+    readonly property int clipboardCount: clipboardEvents.length
 
     visible: false
     width: 0
@@ -106,6 +111,111 @@ Item {
     function allWritable(fallback) {
         const selected = events(fallback);
         return selected.length > 0 && selected.every(event => !event.readOnly);
+    }
+
+    function writableCalendarId(preferredId) {
+        const writable = DankCalService.writableCalendars();
+        for (let i = 0; i < writable.length; i++) {
+            if (writable[i].id === preferredId)
+                return preferredId;
+        }
+        const fallback = DankCalService.defaultCalendar();
+        return fallback ? fallback.id : "";
+    }
+
+    function finishOperation(verb, total, response) {
+        busy = false;
+        const completed = (response.results || []).length;
+        if (response.error) {
+            ToastService.info(I18n.tr("%1 of %2 events %3", "partial batch event action result; %1 completed count, %2 total count, %3 action verb").arg(completed).arg(total).arg(verb));
+            return;
+        }
+        ToastService.info(total === 1 ? I18n.tr("1 event %1", "single event action result; %1 is an action verb").arg(verb) : I18n.tr("%1 events %2", "multiple event action result; %1 is event count, %2 is an action verb").arg(total).arg(verb));
+    }
+
+    function copy(fallback) {
+        if (fallback)
+            ensureSelected(fallback);
+        const selected = events(fallback);
+        if (selected.length === 0)
+            return;
+        Quickshell.clipboardText = EventUtils.clipboardText(selected);
+        ToastService.info(selected.length === 1 ? I18n.tr("Copied 1 event", "clipboard confirmation for one event") : I18n.tr("Copied %1 events", "clipboard confirmation for multiple events; %1 is event count").arg(selected.length));
+    }
+
+    function paste(targetDay) {
+        const copied = EventUtils.clipboardEvents(Quickshell.clipboardText);
+        if (copied.length === 0 || busy)
+            return;
+        const fallbackId = writableCalendarId("");
+        if (fallbackId === "") {
+            ToastService.info(I18n.tr("No writable calendar available", "event paste error when no calendar allows creating events"));
+            return;
+        }
+        const fields = EventUtils.pasteFields(copied, targetDay, fallbackId);
+        for (let i = 0; i < fields.length; i++)
+            fields[i].calendarId = writableCalendarId(fields[i].calendarId);
+        busy = true;
+        DankCalService.createEvents(fields, response => {
+            root.finishOperation(I18n.tr("pasted", "past-tense event action used in a result message"), fields.length, response);
+            root.clear();
+        });
+    }
+
+    function duplicate(dayOffset, fallback) {
+        if (busy)
+            return;
+        if (fallback)
+            ensureSelected(fallback);
+        const selected = events(fallback);
+        const fields = [];
+        for (let i = 0; i < selected.length; i++) {
+            const calendarId = writableCalendarId(selected[i].calendarId);
+            if (calendarId !== "")
+                fields.push(EventUtils.createFields(selected[i], dayOffset, calendarId, false));
+        }
+        if (fields.length === 0) {
+            ToastService.info(I18n.tr("No writable calendar available", "event duplicate error when no calendar allows creating events"));
+            return;
+        }
+        busy = true;
+        DankCalService.createEvents(fields, response => root.finishOperation(I18n.tr("created", "past-tense event action used in a result message"), fields.length, response));
+    }
+
+    function moveTo(anchorEvent, targetDay) {
+        if (busy)
+            return;
+        ensureSelected(anchorEvent);
+        const selected = events(anchorEvent);
+        if (!allWritable(anchorEvent)) {
+            ToastService.info(I18n.tr("Read-only events can't be moved", "event move error for a read-only calendar"));
+            return;
+        }
+        const offset = EventUtils.daysBetween(anchorEvent.start, targetDay);
+        if (offset === 0)
+            return;
+        busy = true;
+        DankCalService.moveEvents(selected, offset, response => {
+            root.finishOperation(I18n.tr("moved", "past-tense event action used in a result message"), selected.length, response);
+            root.clear();
+        });
+    }
+
+    function remove(fallback) {
+        if (busy)
+            return;
+        if (fallback)
+            ensureSelected(fallback);
+        const selected = events(fallback);
+        if (!allWritable(fallback)) {
+            ToastService.info(I18n.tr("Read-only events can't be deleted", "event delete error for a read-only calendar"));
+            return;
+        }
+        busy = true;
+        DankCalService.deleteEvents(selected, response => {
+            root.finishOperation(I18n.tr("deleted", "past-tense event action used in a result message"), selected.length, response);
+            root.clear();
+        });
     }
 
     Connections {

--- a/quickshell/tests/tst_EventUtils.qml
+++ b/quickshell/tests/tst_EventUtils.qml
@@ -72,6 +72,19 @@ TestCase {
         compare(copied.length, 1);
     }
 
+    function test_cutClipboardRetainsSourceForMoveAfterPaste() {
+        const original = event({
+            "recurringId": "series-1",
+            "recurrence": ["FREQ=WEEKLY"]
+        });
+        const copied = EventUtils.clipboardEvents(EventUtils.clipboardText([original], true));
+
+        compare(copied.length, 1);
+        compare(copied[0]._dankCut.id, original.id);
+        compare(copied[0]._dankCut.start, original.start.toISOString());
+        compare(copied[0]._dankCut.recurrence[0], "FREQ=WEEKLY");
+    }
+
     function test_pasteAnchorsGroupToTargetDay() {
         const first = EventUtils.createFields(event(), 0, "calendar-1", false);
         const second = EventUtils.createFields(event({

--- a/quickshell/tests/tst_EventUtils.qml
+++ b/quickshell/tests/tst_EventUtils.qml
@@ -18,10 +18,12 @@ TestCase {
             "allDay": false,
             "recurringId": "",
             "recurrence": [],
-            "reminders": [{
-                "method": "popup",
-                "minutes": 10
-            }]
+            "reminders": [
+                {
+                    "method": "popup",
+                    "minutes": 10
+                }
+            ]
         }, overrides || {});
     }
 
@@ -99,6 +101,18 @@ TestCase {
         compare(new Date(pasted[0].start).getHours(), 9);
         compare(new Date(pasted[1].start).getDate(), 22);
         compare(new Date(pasted[1].start).getHours(), 14);
+    }
+
+    function test_clipboardFoldsLongLinesAndRoundTrips() {
+        const original = event({
+            "description": "réunion ".repeat(60).trim()
+        });
+        const text = EventUtils.clipboardText([original]);
+        const copied = EventUtils.clipboardEvents(text);
+
+        verify(text.split("\r\n").every(line => line.length <= 75));
+        compare(copied.length, 1);
+        compare(copied[0].description, original.description);
     }
 
     function test_allDayCopyUsesDateValues() {

--- a/quickshell/tests/tst_EventUtils.qml
+++ b/quickshell/tests/tst_EventUtils.qml
@@ -1,0 +1,102 @@
+import QtQuick
+import QtTest
+import "../Common/EventUtils.js" as EventUtils
+
+TestCase {
+    name: "EventUtils"
+
+    function event(overrides) {
+        return Object.assign({
+            "id": "event-1",
+            "uid": "uid-1",
+            "calendarId": "calendar-1",
+            "title": "Design review",
+            "description": "Review, refine; ship\nBring notes",
+            "location": "Studio A",
+            "start": new Date(2026, 7, 10, 9, 30),
+            "end": new Date(2026, 7, 10, 10, 45),
+            "allDay": false,
+            "recurringId": "",
+            "recurrence": [],
+            "reminders": [{
+                "method": "popup",
+                "minutes": 10
+            }]
+        }, overrides || {});
+    }
+
+    function test_moveFieldsPreserveLocalTimeAndDuration() {
+        const original = event();
+        const fields = EventUtils.moveFields(original, 3);
+        const start = new Date(fields.start);
+        const end = new Date(fields.end);
+
+        compare(start.getDate(), 13);
+        compare(start.getHours(), 9);
+        compare(start.getMinutes(), 30);
+        compare(end.getTime() - start.getTime(), 75 * 60000);
+        verify(fields.occurrenceStart === undefined);
+    }
+
+    function test_recurringMoveIdentifiesOccurrence() {
+        const original = event({
+            "recurringId": "series-1",
+            "recurrence": ["FREQ=WEEKLY"]
+        });
+        const fields = EventUtils.moveFields(original, 1);
+
+        compare(fields.occurrenceStart, original.start.toISOString());
+    }
+
+    function test_clipboardRoundTripPreservesEditableFields() {
+        const original = event({
+            "title": "Déjeuner & planning"
+        });
+        const text = EventUtils.clipboardText([original]);
+        const copied = EventUtils.clipboardEvents(text);
+
+        verify(text.indexOf("BEGIN:VCALENDAR") !== -1);
+        verify(text.indexOf("SUMMARY:Déjeuner & planning") !== -1);
+        compare(copied.length, 1);
+        compare(copied[0].summary, original.title);
+        compare(copied[0].description, original.description);
+        compare(copied[0].reminders[0].minutes, 10);
+        verify(copied[0].recurrence === undefined);
+    }
+
+    function test_clipboardSkipsDuplicatesAndMalformedEntries() {
+        const original = event();
+        const text = EventUtils.clipboardText([original, original]) + "\r\nX-DANKCALENDAR-EVENT:not-json";
+        const copied = EventUtils.clipboardEvents(text);
+
+        compare(copied.length, 1);
+    }
+
+    function test_pasteAnchorsGroupToTargetDay() {
+        const first = EventUtils.createFields(event(), 0, "calendar-1", false);
+        const second = EventUtils.createFields(event({
+            "id": "event-2",
+            "uid": "uid-2",
+            "start": new Date(2026, 7, 12, 14, 0),
+            "end": new Date(2026, 7, 12, 15, 0)
+        }), 0, "calendar-1", false);
+        const pasted = EventUtils.pasteFields([second, first], new Date(2026, 7, 20), "fallback");
+
+        compare(new Date(pasted[0].start).getDate(), 20);
+        compare(new Date(pasted[0].start).getHours(), 9);
+        compare(new Date(pasted[1].start).getDate(), 22);
+        compare(new Date(pasted[1].start).getHours(), 14);
+    }
+
+    function test_allDayCopyUsesDateValues() {
+        const original = event({
+            "allDay": true,
+            "start": new Date(2026, 7, 10),
+            "end": new Date(2026, 7, 11)
+        });
+        const text = EventUtils.clipboardText([original]);
+
+        verify(text.indexOf("DTSTART;VALUE=DATE:20260810") !== -1);
+        verify(text.indexOf("DTEND;VALUE=DATE:20260811") !== -1);
+    }
+}

--- a/quickshell/translations/en.json
+++ b/quickshell/translations/en.json
@@ -20,25 +20,25 @@
   {
     "term": "%1 events %2",
     "context": "%1 events %2",
-    "reference": "Widgets/EventSelectionModel.qml:133",
+    "reference": "Widgets/EventSelectionModel.qml:134",
     "comment": "multiple event action result; %1 is event count, %2 is an action verb"
   },
   {
     "term": "%1 events selected",
     "context": "%1 events selected",
-    "reference": "Widgets/EventContextMenu.qml:95",
+    "reference": "Widgets/EventContextMenu.qml:98",
     "comment": "event context menu selection summary; %1 is event count"
   },
   {
     "term": "%1 of %2 events %3",
     "context": "%1 of %2 events %3",
-    "reference": "Widgets/EventSelectionModel.qml:130",
+    "reference": "Widgets/EventSelectionModel.qml:131",
     "comment": "partial batch event action result; %1 completed count, %2 total count, %3 action verb"
   },
   {
     "term": "%1 selected",
     "context": "%1 selected",
-    "reference": "Widgets/EventSelectionBar.qml:115",
+    "reference": "Widgets/EventSelectionBar.qml:124",
     "comment": "multi-event action shelf selection count; %1 is event count"
   },
   {
@@ -110,13 +110,13 @@
   {
     "term": "+1 day",
     "context": "+1 day",
-    "reference": "Widgets/EventSelectionBar.qml:26",
+    "reference": "Widgets/EventSelectionBar.qml:32",
     "comment": "multi-event action shelf repeat tomorrow label"
   },
   {
     "term": "+1 week",
     "context": "+1 week",
-    "reference": "Widgets/EventSelectionBar.qml:31",
+    "reference": "Widgets/EventSelectionBar.qml:37",
     "comment": "multi-event action shelf repeat next week label"
   },
   {
@@ -134,7 +134,7 @@
   {
     "term": "1 event %1",
     "context": "1 event %1",
-    "reference": "Widgets/EventSelectionModel.qml:133",
+    "reference": "Widgets/EventSelectionModel.qml:134",
     "comment": "single event action result; %1 is an action verb"
   },
   {
@@ -332,7 +332,7 @@
   {
     "term": "Actions apply to the whole selection",
     "context": "Actions apply to the whole selection",
-    "reference": "Widgets/EventContextMenu.qml:96",
+    "reference": "Widgets/EventContextMenu.qml:99",
     "comment": "event context menu multi-selection hint"
   },
   {
@@ -404,7 +404,7 @@
   {
     "term": "Again",
     "context": "Again",
-    "reference": "Widgets/EventSelectionBar.qml:21",
+    "reference": "Widgets/EventSelectionBar.qml:27",
     "comment": "multi-event action shelf duplicate label"
   },
   {
@@ -428,7 +428,7 @@
   {
     "term": "All day",
     "context": "All day",
-    "reference": "Modals/SearchModal.qml:81, Modals/EventDetailsModal.qml:1108, Widgets/EventContextMenu.qml:46, Modules/views/MonthDayPopover.qml:163, Modules/views/MonthView.qml:140, Modules/views/WeekView.qml:151, Modules/views/DayView.qml:62, Modules/views/AgendaView.qml:81",
+    "reference": "Modals/SearchModal.qml:81, Modals/EventDetailsModal.qml:1108, Widgets/EventContextMenu.qml:40, Modules/views/MonthDayPopover.qml:163, Modules/views/MonthView.qml:140, Modules/views/WeekView.qml:151, Modules/views/DayView.qml:62, Modules/views/AgendaView.qml:81",
     "comment": "all-day marker in event context menu | all-day marker in event tooltip | all-day marker in the month day-detail popover | event form toggle label for all-day events | search result subtitle for all-day events | time column label for all-day events on agenda card"
   },
   {
@@ -554,7 +554,7 @@
   {
     "term": "Calendar",
     "context": "Calendar",
-    "reference": "Modules/CalendarWindow.qml:387, Modules/CalendarWindow.qml:686",
+    "reference": "Modules/CalendarWindow.qml:387, Modules/CalendarWindow.qml:693",
     "comment": "main window title | main window title bar text"
   },
   {
@@ -620,7 +620,7 @@
   {
     "term": "Clear",
     "context": "Clear",
-    "reference": "Widgets/EventSelectionBar.qml:42",
+    "reference": "Widgets/EventSelectionBar.qml:48",
     "comment": "multi-event action shelf clear selection label"
   },
   {
@@ -752,13 +752,13 @@
   {
     "term": "Copied %1 events",
     "context": "Copied %1 events",
-    "reference": "Widgets/EventSelectionModel.qml:143",
+    "reference": "Widgets/EventSelectionModel.qml:144",
     "comment": "clipboard confirmation for multiple events; %1 is event count"
   },
   {
     "term": "Copied 1 event",
     "context": "Copied 1 event",
-    "reference": "Widgets/EventSelectionModel.qml:143",
+    "reference": "Widgets/EventSelectionModel.qml:144",
     "comment": "clipboard confirmation for one event"
   },
   {
@@ -770,19 +770,19 @@
   {
     "term": "Copy",
     "context": "Copy",
-    "reference": "Widgets/EventSelectionBar.qml:16",
+    "reference": "Widgets/EventSelectionBar.qml:17",
     "comment": "multi-event action shelf label"
   },
   {
     "term": "Copy %1 events",
     "context": "Copy %1 events",
-    "reference": "Widgets/EventContextMenu.qml:105",
+    "reference": "Widgets/EventContextMenu.qml:108",
     "comment": "event context menu copy action; %1 is event count"
   },
   {
     "term": "Copy event",
     "context": "Copy event",
-    "reference": "Widgets/EventContextMenu.qml:105",
+    "reference": "Widgets/EventContextMenu.qml:108",
     "comment": "event context menu copy action for one event"
   },
   {
@@ -790,6 +790,12 @@
     "context": "Copy link",
     "reference": "Modals/AccountAddModal.qml:922, Modals/AccountAddModal.qml:1262",
     "comment": "button to copy a setup guide url to the clipboard"
+  },
+  {
+    "term": "Copy selected events",
+    "context": "Copy selected events",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:140",
+    "comment": "keyboard shortcut description"
   },
   {
     "term": "Core hours",
@@ -824,7 +830,7 @@
   {
     "term": "Create event",
     "context": "Create event",
-    "reference": "Modals/KeyboardShortcutsOverlay.qml:140, Modules/CalendarSidebar.qml:419",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:169, Modules/CalendarSidebar.qml:419",
     "comment": "keyboard shortcut description | sidebar button to create a new event"
   },
   {
@@ -838,6 +844,36 @@
     "context": "Custom",
     "reference": "Modals/SettingsContent.qml:25, Widgets/DankRecurrencePicker.qml:56",
     "comment": "color source button group option for a custom theme file | recurrence dropdown option"
+  },
+  {
+    "term": "Cut",
+    "context": "Cut",
+    "reference": "Widgets/EventSelectionBar.qml:22",
+    "comment": "multi-event action shelf label"
+  },
+  {
+    "term": "Cut %1 events",
+    "context": "Cut %1 events",
+    "reference": "Widgets/EventContextMenu.qml:115, Widgets/EventSelectionModel.qml:156",
+    "comment": "clipboard confirmation for multiple events; %1 is event count | event context menu cut action; %1 is event count"
+  },
+  {
+    "term": "Cut 1 event",
+    "context": "Cut 1 event",
+    "reference": "Widgets/EventSelectionModel.qml:156",
+    "comment": "clipboard confirmation for one event"
+  },
+  {
+    "term": "Cut event",
+    "context": "Cut event",
+    "reference": "Widgets/EventContextMenu.qml:115",
+    "comment": "event context menu cut action for one event"
+  },
+  {
+    "term": "Cut selected events",
+    "context": "Cut selected events",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:144",
+    "comment": "keyboard shortcut description"
   },
   {
     "term": "Daemon offline",
@@ -884,7 +920,7 @@
   {
     "term": "Day actions",
     "context": "Day actions",
-    "reference": "Widgets/EventContextMenu.qml:56",
+    "reference": "Widgets/EventContextMenu.qml:59",
     "comment": "subtitle for a calendar day context menu"
   },
   {
@@ -920,7 +956,7 @@
   {
     "term": "Delete",
     "context": "Delete",
-    "reference": "Modals/TaskDetailsModal.qml:503, Modals/SettingsContent.qml:1018, Modals/SettingsContent.qml:1024, Modules/CalendarSidebar.qml:302, Widgets/EventSelectionBar.qml:36",
+    "reference": "Modals/TaskDetailsModal.qml:503, Modals/SettingsContent.qml:1018, Modals/SettingsContent.qml:1024, Modules/CalendarSidebar.qml:302, Widgets/EventSelectionBar.qml:42",
     "comment": "calendar row action tooltip | confirm button for deleting a calendar | delete calendar confirmation button | multi-event action shelf label | task form button to delete the task"
   },
   {
@@ -944,7 +980,7 @@
   {
     "term": "Delete %1 events…",
     "context": "Delete %1 events…",
-    "reference": "Widgets/EventContextMenu.qml:149",
+    "reference": "Widgets/EventContextMenu.qml:159",
     "comment": "event context menu delete action; %1 is event count"
   },
   {
@@ -962,7 +998,7 @@
   {
     "term": "Delete event…",
     "context": "Delete event…",
-    "reference": "Widgets/EventContextMenu.qml:149",
+    "reference": "Widgets/EventContextMenu.qml:159",
     "comment": "event context menu delete action for one event"
   },
   {
@@ -970,6 +1006,12 @@
     "context": "Delete occurrence",
     "reference": "Modals/EventDetailsModal.qml:587",
     "comment": "event details button to delete only this occurrence of a recurring event"
+  },
+  {
+    "term": "Delete selected events",
+    "context": "Delete selected events",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:160",
+    "comment": "keyboard shortcut description"
   },
   {
     "term": "Delete series",
@@ -1064,8 +1106,20 @@
   {
     "term": "Duplicate",
     "context": "Duplicate",
-    "reference": "Widgets/EventContextMenu.qml:112",
-    "comment": "event context menu duplicate action"
+    "reference": "Widgets/EventContextMenu.qml:122",
+    "comment": "event context menu duplicate action for one event"
+  },
+  {
+    "term": "Duplicate %1 events",
+    "context": "Duplicate %1 events",
+    "reference": "Widgets/EventContextMenu.qml:122",
+    "comment": "event context menu duplicate action; %1 is event count"
+  },
+  {
+    "term": "Duplicate selected events",
+    "context": "Duplicate selected events",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:152",
+    "comment": "keyboard shortcut description"
   },
   {
     "term": "Edit event",
@@ -1140,6 +1194,12 @@
     "comment": "event modal window title when viewing"
   },
   {
+    "term": "Event actions",
+    "context": "Event actions",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:136",
+    "comment": "keyboard shortcuts overlay section header"
+  },
+  {
     "term": "Event details",
     "context": "Event details",
     "reference": "Modals/EventDetailsModal.qml:563",
@@ -1196,7 +1256,7 @@
   {
     "term": "General",
     "context": "General",
-    "reference": "Modals/SettingsSidebar.qml:16, Modals/KeyboardShortcutsOverlay.qml:136, Modals/SettingsContent.qml:373",
+    "reference": "Modals/SettingsSidebar.qml:16, Modals/SettingsContent.qml:373, Modals/KeyboardShortcutsOverlay.qml:165",
     "comment": "general settings section header | keyboard shortcuts overlay section header | settings sidebar tab label"
   },
   {
@@ -1298,7 +1358,7 @@
   {
     "term": "Keyboard shortcuts",
     "context": "Keyboard shortcuts",
-    "reference": "Modals/KeyboardShortcutsOverlay.qml:205",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:234",
     "comment": "keyboard shortcuts overlay title"
   },
   {
@@ -1458,6 +1518,18 @@
     "comment": "event drag preview label; %1 is event count"
   },
   {
+    "term": "Move %1 events here",
+    "context": "Move %1 events here",
+    "reference": "Widgets/EventContextMenu.qml:47",
+    "comment": "calendar context menu cut-paste action; %1 is event count"
+  },
+  {
+    "term": "Move 1 event here",
+    "context": "Move 1 event here",
+    "reference": "Widgets/EventContextMenu.qml:47",
+    "comment": "calendar context menu cut-paste action for one event"
+  },
+  {
     "term": "Move through sidebar items",
     "context": "Move through sidebar items",
     "reference": "Modals/KeyboardShortcutsOverlay.qml:111",
@@ -1466,7 +1538,7 @@
   {
     "term": "Move to selected day",
     "context": "Move to selected day",
-    "reference": "Widgets/EventContextMenu.qml:131",
+    "reference": "Widgets/EventContextMenu.qml:141",
     "comment": "event context menu move action"
   },
   {
@@ -1508,7 +1580,7 @@
   {
     "term": "New event",
     "context": "New event",
-    "reference": "Modals/EventDetailsModal.qml:511, Modals/EventDetailsModal.qml:563, Widgets/EventContextMenu.qml:60, Modules/views/MonthView.qml:385",
+    "reference": "Modals/EventDetailsModal.qml:511, Modals/EventDetailsModal.qml:563, Widgets/EventContextMenu.qml:63, Modules/views/MonthView.qml:385",
     "comment": "calendar day context menu action | event modal header when creating | event modal window title when creating | placeholder label on the event span shown while selecting days in the month grid"
   },
   {
@@ -1610,7 +1682,7 @@
   {
     "term": "No writable calendar available",
     "context": "No writable calendar available",
-    "reference": "Modals/EventDetailsModal.qml:338, Widgets/EventSelectionModel.qml:152, Widgets/EventSelectionModel.qml:178",
+    "reference": "Modals/EventDetailsModal.qml:338, Widgets/EventSelectionModel.qml:165, Widgets/EventSelectionModel.qml:205",
     "comment": "event duplicate error when no calendar allows creating events | event form error when no calendar allows creating events | event paste error when no calendar allows creating events"
   },
   {
@@ -1700,8 +1772,14 @@
   {
     "term": "Open event",
     "context": "Open event",
-    "reference": "Widgets/EventContextMenu.qml:88",
+    "reference": "Widgets/EventContextMenu.qml:91",
     "comment": "event context menu action"
+  },
+  {
+    "term": "Open event actions",
+    "context": "Open event actions",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:156",
+    "comment": "keyboard shortcut description"
   },
   {
     "term": "Open or create event",
@@ -1760,25 +1838,25 @@
   {
     "term": "Paste %1 events",
     "context": "Paste %1 events",
-    "reference": "Widgets/EventContextMenu.qml:65",
+    "reference": "Widgets/EventContextMenu.qml:50",
     "comment": "calendar day context menu paste action; %1 is event count"
   },
   {
     "term": "Paste %1 events here",
     "context": "Paste %1 events here",
-    "reference": "Widgets/EventContextMenu.qml:138",
+    "reference": "Widgets/EventContextMenu.qml:49",
     "comment": "event context menu paste action; %1 is event count"
   },
   {
     "term": "Paste 1 event",
     "context": "Paste 1 event",
-    "reference": "Widgets/EventContextMenu.qml:65",
+    "reference": "Widgets/EventContextMenu.qml:50",
     "comment": "calendar day context menu paste action for one event"
   },
   {
     "term": "Paste 1 event here",
     "context": "Paste 1 event here",
-    "reference": "Widgets/EventContextMenu.qml:138",
+    "reference": "Widgets/EventContextMenu.qml:49",
     "comment": "event context menu paste action for one event"
   },
   {
@@ -1786,6 +1864,12 @@
     "context": "Paste credentials",
     "reference": "Modals/AccountAddModal.qml:942",
     "comment": "last guide step button to google credentials"
+  },
+  {
+    "term": "Paste events on the selected day",
+    "context": "Paste events on the selected day",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:148",
+    "comment": "keyboard shortcut description"
   },
   {
     "term": "Paste the Application (client) ID from your app registration's Overview page.",
@@ -1872,15 +1956,21 @@
     "comment": "close behavior button group option to quit the app | tray menu item to quit the application"
   },
   {
+    "term": "Read-only events can't be cut",
+    "context": "Read-only events can't be cut",
+    "reference": "Widgets/EventSelectionModel.qml:152",
+    "comment": "event cut error for a read-only calendar"
+  },
+  {
     "term": "Read-only events can't be deleted",
     "context": "Read-only events can't be deleted",
-    "reference": "Widgets/EventSelectionModel.qml:211",
+    "reference": "Widgets/EventSelectionModel.qml:238",
     "comment": "event delete error for a read-only calendar"
   },
   {
     "term": "Read-only events can't be moved",
     "context": "Read-only events can't be moved",
-    "reference": "Widgets/EventSelectionModel.qml:191",
+    "reference": "Widgets/EventSelectionModel.qml:218",
     "comment": "event move error for a read-only calendar"
   },
   {
@@ -1986,16 +2076,28 @@
     "comment": "task form label for the recurrence dropdown"
   },
   {
+    "term": "Repeat %1 events next week",
+    "context": "Repeat %1 events next week",
+    "reference": "Widgets/EventContextMenu.qml:135",
+    "comment": "event context menu quick repeat action; %1 is event count"
+  },
+  {
+    "term": "Repeat %1 events tomorrow",
+    "context": "Repeat %1 events tomorrow",
+    "reference": "Widgets/EventContextMenu.qml:129",
+    "comment": "event context menu quick repeat action; %1 is event count"
+  },
+  {
     "term": "Repeat next week",
     "context": "Repeat next week",
-    "reference": "Widgets/EventContextMenu.qml:125",
-    "comment": "event context menu quick repeat action"
+    "reference": "Widgets/EventContextMenu.qml:135",
+    "comment": "event context menu quick repeat action for one event"
   },
   {
     "term": "Repeat tomorrow",
     "context": "Repeat tomorrow",
-    "reference": "Widgets/EventContextMenu.qml:119",
-    "comment": "event context menu quick repeat action"
+    "reference": "Widgets/EventContextMenu.qml:129",
+    "comment": "event context menu quick repeat action for one event"
   },
   {
     "term": "Repeats",
@@ -2036,7 +2138,7 @@
   {
     "term": "Search",
     "context": "Search",
-    "reference": "Modals/KeyboardShortcutsOverlay.qml:144",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:173",
     "comment": "keyboard shortcut description"
   },
   {
@@ -2060,7 +2162,7 @@
   {
     "term": "Select all %1 events",
     "context": "Select all %1 events",
-    "reference": "Widgets/EventContextMenu.qml:73",
+    "reference": "Widgets/EventContextMenu.qml:76",
     "comment": "calendar day context menu selection action; %1 is event count"
   },
   {
@@ -2078,7 +2180,7 @@
   {
     "term": "Select event",
     "context": "Select event",
-    "reference": "Widgets/EventContextMenu.qml:73",
+    "reference": "Widgets/EventContextMenu.qml:76",
     "comment": "calendar day context menu action for one event"
   },
   {
@@ -2108,7 +2210,7 @@
   {
     "term": "Settings",
     "context": "Settings",
-    "reference": "Modals/SettingsModal.qml:87, Modals/KeyboardShortcutsOverlay.qml:148",
+    "reference": "Modals/SettingsModal.qml:87, Modals/KeyboardShortcutsOverlay.qml:177",
     "comment": "keyboard shortcut description | settings window header title"
   },
   {
@@ -2402,7 +2504,7 @@
   {
     "term": "Toggle this help",
     "context": "Toggle this help",
-    "reference": "Modals/KeyboardShortcutsOverlay.qml:152",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:181",
     "comment": "keyboard shortcut description"
   },
   {
@@ -2606,7 +2708,7 @@
   {
     "term": "created",
     "context": "created",
-    "reference": "Widgets/EventSelectionModel.qml:182",
+    "reference": "Widgets/EventSelectionModel.qml:209",
     "comment": "past-tense event action used in a result message"
   },
   {
@@ -2630,7 +2732,7 @@
   {
     "term": "deleted",
     "context": "deleted",
-    "reference": "Widgets/EventSelectionModel.qml:216",
+    "reference": "Widgets/EventSelectionModel.qml:243",
     "comment": "past-tense event action used in a result message"
   },
   {
@@ -2638,12 +2740,6 @@
     "context": "e.g. 2022-01-01",
     "reference": "Modals/GoToDateDialog.qml:207",
     "comment": "go to date input placeholder example"
-  },
-  {
-    "term": "events",
-    "context": "events",
-    "reference": "Widgets/EventContextMenu.qml:42",
-    "comment": "plural event noun in context menu actions"
   },
   {
     "term": "iCal subscription",
@@ -2672,7 +2768,7 @@
   {
     "term": "moved",
     "context": "moved",
-    "reference": "Widgets/EventSelectionModel.qml:199",
+    "reference": "Widgets/EventSelectionModel.qml:184, Widgets/EventSelectionModel.qml:226",
     "comment": "past-tense event action used in a result message"
   },
   {
@@ -2696,7 +2792,7 @@
   {
     "term": "pasted",
     "context": "pasted",
-    "reference": "Widgets/EventSelectionModel.qml:160",
+    "reference": "Widgets/EventSelectionModel.qml:179",
     "comment": "past-tense event action used in a result message"
   },
   {

--- a/quickshell/translations/en.json
+++ b/quickshell/translations/en.json
@@ -2,25 +2,49 @@
   {
     "term": "%1 AM",
     "context": "%1 AM",
-    "reference": "Modals/SettingsContent.qml:115, Modules/views/DayView.qml:64, Modules/views/WeekView.qml:98",
+    "reference": "Modals/SettingsContent.qml:115, Modules/views/WeekView.qml:134, Modules/views/DayView.qml:72",
     "comment": "core hours dropdown hour label, morning | morning hour label in time gutter"
   },
   {
     "term": "%1 PM",
     "context": "%1 PM",
-    "reference": "Modals/SettingsContent.qml:115, Modules/views/DayView.qml:64, Modules/views/WeekView.qml:98",
+    "reference": "Modals/SettingsContent.qml:115, Modules/views/WeekView.qml:134, Modules/views/DayView.qml:72",
     "comment": "afternoon hour label in time gutter | core hours dropdown hour label, afternoon"
   },
   {
     "term": "%1 appointments fall outside core hours",
     "context": "%1 appointments fall outside core hours",
-    "reference": "Modules/views/DayView.qml:153, Modules/views/WeekView.qml:245",
+    "reference": "Modules/views/WeekView.qml:281, Modules/views/DayView.qml:161",
     "comment": "core hours warning banner, plural"
+  },
+  {
+    "term": "%1 events %2",
+    "context": "%1 events %2",
+    "reference": "Widgets/EventSelectionModel.qml:133",
+    "comment": "multiple event action result; %1 is event count, %2 is an action verb"
+  },
+  {
+    "term": "%1 events selected",
+    "context": "%1 events selected",
+    "reference": "Widgets/EventContextMenu.qml:95",
+    "comment": "event context menu selection summary; %1 is event count"
+  },
+  {
+    "term": "%1 of %2 events %3",
+    "context": "%1 of %2 events %3",
+    "reference": "Widgets/EventSelectionModel.qml:130",
+    "comment": "partial batch event action result; %1 completed count, %2 total count, %3 action verb"
+  },
+  {
+    "term": "%1 selected",
+    "context": "%1 selected",
+    "reference": "Widgets/EventSelectionBar.qml:115",
+    "comment": "multi-event action shelf selection count; %1 is event count"
   },
   {
     "term": "%1 times",
     "context": "%1 times",
-    "reference": "Services/DankCalService.qml:919",
+    "reference": "Services/DankCalService.qml:1018",
     "comment": "recurrence label suffix for a fixed number of occurrences"
   },
   {
@@ -38,7 +62,7 @@
   {
     "term": "%1h",
     "context": "%1h",
-    "reference": "Modules/views/AgendaView.qml:60",
+    "reference": "Modules/views/AgendaView.qml:68",
     "comment": "event duration in hours on agenda card, %1 is hours"
   },
   {
@@ -50,13 +74,13 @@
   {
     "term": "%1h%2m",
     "context": "%1h%2m",
-    "reference": "Modules/views/AgendaView.qml:60",
+    "reference": "Modules/views/AgendaView.qml:68",
     "comment": "event duration on agenda card, %1 is hours and %2 is minutes"
   },
   {
     "term": "%1m",
     "context": "%1m",
-    "reference": "Modules/views/AgendaView.qml:59",
+    "reference": "Modules/views/AgendaView.qml:67",
     "comment": "event duration in minutes on agenda card, %1 is minutes"
   },
   {
@@ -80,20 +104,38 @@
   {
     "term": "+%1 more",
     "context": "+%1 more",
-    "reference": "Modules/views/MonthView.qml:463",
+    "reference": "Modules/views/MonthView.qml:525",
     "comment": "overflow label in month grid day cell, %1 is the number of hidden events"
+  },
+  {
+    "term": "+1 day",
+    "context": "+1 day",
+    "reference": "Widgets/EventSelectionBar.qml:26",
+    "comment": "multi-event action shelf repeat tomorrow label"
+  },
+  {
+    "term": "+1 week",
+    "context": "+1 week",
+    "reference": "Widgets/EventSelectionBar.qml:31",
+    "comment": "multi-event action shelf repeat next week label"
   },
   {
     "term": "1 appointment falls outside core hours",
     "context": "1 appointment falls outside core hours",
-    "reference": "Modules/views/DayView.qml:153, Modules/views/WeekView.qml:245",
+    "reference": "Modules/views/WeekView.qml:281, Modules/views/DayView.qml:161",
     "comment": "core hours warning banner, singular"
   },
   {
     "term": "1 day before",
     "context": "1 day before",
-    "reference": "Modals/EventDetailsModal.qml:77, Modals/SettingsContent.qml:196, Modals/CalendarRemindersDialog.qml:82",
+    "reference": "Modals/CalendarRemindersDialog.qml:82, Modals/EventDetailsModal.qml:77, Modals/SettingsContent.qml:196",
     "comment": "all-day reminder day dropdown option | event reminder dropdown option"
+  },
+  {
+    "term": "1 event %1",
+    "context": "1 event %1",
+    "reference": "Widgets/EventSelectionModel.qml:133",
+    "comment": "single event action result; %1 is an action verb"
   },
   {
     "term": "1 hour",
@@ -104,7 +146,7 @@
   {
     "term": "1 hour before",
     "context": "1 hour before",
-    "reference": "Modals/EventDetailsModal.qml:69, Modals/SettingsContent.qml:166, Modals/CalendarRemindersDialog.qml:54",
+    "reference": "Modals/CalendarRemindersDialog.qml:54, Modals/EventDetailsModal.qml:69, Modals/SettingsContent.qml:166",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -122,7 +164,7 @@
   {
     "term": "1 week before",
     "context": "1 week before",
-    "reference": "Modals/EventDetailsModal.qml:85, Modals/SettingsContent.qml:204, Modals/CalendarRemindersDialog.qml:90",
+    "reference": "Modals/CalendarRemindersDialog.qml:90, Modals/EventDetailsModal.qml:85, Modals/SettingsContent.qml:204",
     "comment": "all-day reminder day dropdown option | event reminder dropdown option"
   },
   {
@@ -134,13 +176,13 @@
   {
     "term": "10 minutes",
     "context": "10 minutes",
-    "reference": "Modals/SettingsContent.qml:177, Modals/CalendarRemindersDialog.qml:64",
+    "reference": "Modals/CalendarRemindersDialog.qml:64, Modals/SettingsContent.qml:177",
     "comment": "snooze duration dropdown option"
   },
   {
     "term": "10 minutes before",
     "context": "10 minutes before",
-    "reference": "Modals/EventDetailsModal.qml:57, Modals/SettingsContent.qml:154, Modals/CalendarRemindersDialog.qml:42",
+    "reference": "Modals/CalendarRemindersDialog.qml:42, Modals/EventDetailsModal.qml:57, Modals/SettingsContent.qml:154",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -158,19 +200,19 @@
   {
     "term": "15 minutes",
     "context": "15 minutes",
-    "reference": "Modals/SettingsContent.qml:84, Modals/SettingsContent.qml:181, Modals/SettingsContent.qml:219, Modals/CalendarRemindersDialog.qml:68",
+    "reference": "Modals/CalendarRemindersDialog.qml:68, Modals/SettingsContent.qml:84, Modals/SettingsContent.qml:181, Modals/SettingsContent.qml:219",
     "comment": "default event duration option | snooze duration dropdown option | sync interval dropdown option"
   },
   {
     "term": "15 minutes before",
     "context": "15 minutes before",
-    "reference": "Modals/EventDetailsModal.qml:61, Modals/SettingsContent.qml:158, Modals/CalendarRemindersDialog.qml:46",
+    "reference": "Modals/CalendarRemindersDialog.qml:46, Modals/EventDetailsModal.qml:61, Modals/SettingsContent.qml:158",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
     "term": "2 days before",
     "context": "2 days before",
-    "reference": "Modals/EventDetailsModal.qml:81, Modals/SettingsContent.qml:200, Modals/CalendarRemindersDialog.qml:86",
+    "reference": "Modals/CalendarRemindersDialog.qml:86, Modals/EventDetailsModal.qml:81, Modals/SettingsContent.qml:200",
     "comment": "all-day reminder day dropdown option | event reminder dropdown option"
   },
   {
@@ -212,13 +254,13 @@
   {
     "term": "30 minutes",
     "context": "30 minutes",
-    "reference": "Modals/SettingsContent.qml:88, Modals/SettingsContent.qml:185, Modals/SettingsContent.qml:223, Modals/CalendarRemindersDialog.qml:72",
+    "reference": "Modals/CalendarRemindersDialog.qml:72, Modals/SettingsContent.qml:88, Modals/SettingsContent.qml:185, Modals/SettingsContent.qml:223",
     "comment": "default event duration option | snooze duration dropdown option | sync interval dropdown option"
   },
   {
     "term": "30 minutes before",
     "context": "30 minutes before",
-    "reference": "Modals/EventDetailsModal.qml:65, Modals/SettingsContent.qml:162, Modals/CalendarRemindersDialog.qml:50",
+    "reference": "Modals/CalendarRemindersDialog.qml:50, Modals/EventDetailsModal.qml:65, Modals/SettingsContent.qml:162",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -230,13 +272,13 @@
   {
     "term": "5 minutes",
     "context": "5 minutes",
-    "reference": "Modals/SettingsContent.qml:173, Modals/SettingsContent.qml:215, Modals/CalendarRemindersDialog.qml:60",
+    "reference": "Modals/CalendarRemindersDialog.qml:60, Modals/SettingsContent.qml:173, Modals/SettingsContent.qml:215",
     "comment": "snooze duration dropdown option | sync interval dropdown option"
   },
   {
     "term": "5 minutes before",
     "context": "5 minutes before",
-    "reference": "Modals/EventDetailsModal.qml:53, Modals/SettingsContent.qml:150, Modals/CalendarRemindersDialog.qml:38",
+    "reference": "Modals/CalendarRemindersDialog.qml:38, Modals/EventDetailsModal.qml:53, Modals/SettingsContent.qml:150",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -260,7 +302,7 @@
   {
     "term": "About",
     "context": "About",
-    "reference": "Modals/SettingsSidebar.qml:36, Modals/SettingsAboutPage.qml:229",
+    "reference": "Modals/SettingsAboutPage.qml:229, Modals/SettingsSidebar.qml:36",
     "comment": "about page project section header | settings sidebar tab label"
   },
   {
@@ -284,8 +326,14 @@
   {
     "term": "Accounts",
     "context": "Accounts",
-    "reference": "Modules/CalendarSidebar.qml:798, Modals/SettingsSidebar.qml:28, Modals/SettingsContent.qml:1118",
+    "reference": "Modals/SettingsSidebar.qml:28, Modals/SettingsContent.qml:1118, Modules/CalendarSidebar.qml:798",
     "comment": "accounts settings section header | settings sidebar tab label | sidebar section header for the account list"
+  },
+  {
+    "term": "Actions apply to the whole selection",
+    "context": "Actions apply to the whole selection",
+    "reference": "Widgets/EventContextMenu.qml:96",
+    "comment": "event context menu multi-selection hint"
   },
   {
     "term": "Add",
@@ -308,7 +356,7 @@
   {
     "term": "Add account",
     "context": "Add account",
-    "reference": "Modules/CalendarSidebar.qml:955, Modals/AccountAddModal.qml:220, Modals/AccountAddModal.qml:317, Modals/SettingsContent.qml:1271",
+    "reference": "Modals/AccountAddModal.qml:220, Modals/AccountAddModal.qml:317, Modals/SettingsContent.qml:1271, Modules/CalendarSidebar.qml:955",
     "comment": "account add modal header title | account add modal window title | add account button on accounts page | sidebar button to add a provider account"
   },
   {
@@ -332,7 +380,7 @@
   {
     "term": "Add title",
     "context": "Add title",
-    "reference": "Modals/EventDetailsModal.qml:1063, Modals/TaskDetailsModal.qml:306",
+    "reference": "Modals/TaskDetailsModal.qml:306, Modals/EventDetailsModal.qml:1063",
     "comment": "event form placeholder for title input | task form placeholder for title input"
   },
   {
@@ -354,9 +402,15 @@
     "comment": "recurrence end condition dropdown option, followed by a number of times"
   },
   {
+    "term": "Again",
+    "context": "Again",
+    "reference": "Widgets/EventSelectionBar.qml:21",
+    "comment": "multi-event action shelf duplicate label"
+  },
+  {
     "term": "Agenda",
     "context": "Agenda",
-    "reference": "Modules/CalendarSidebar.qml:51, Modules/CalendarContent.qml:43",
+    "reference": "Modules/CalendarSidebar.qml:51, Modules/CalendarContent.qml:47",
     "comment": "header title when the agenda view is active | view switcher option in sidebar"
   },
   {
@@ -374,8 +428,8 @@
   {
     "term": "All day",
     "context": "All day",
-    "reference": "Modals/EventDetailsModal.qml:1108, Modals/SearchModal.qml:81, Modules/views/AgendaView.qml:73, Modules/views/DayView.qml:54, Modules/views/WeekView.qml:115, Modules/views/MonthView.qml:111, Modules/views/MonthDayPopover.qml:158",
-    "comment": "all-day marker in event tooltip | all-day marker in the month day-detail popover | event form toggle label for all-day events | search result subtitle for all-day events | time column label for all-day events on agenda card"
+    "reference": "Modals/SearchModal.qml:81, Modals/EventDetailsModal.qml:1108, Widgets/EventContextMenu.qml:46, Modules/views/MonthDayPopover.qml:163, Modules/views/MonthView.qml:140, Modules/views/WeekView.qml:151, Modules/views/DayView.qml:62, Modules/views/AgendaView.qml:81",
+    "comment": "all-day marker in event context menu | all-day marker in event tooltip | all-day marker in the month day-detail popover | event form toggle label for all-day events | search result subtitle for all-day events | time column label for all-day events on agenda card"
   },
   {
     "term": "All done",
@@ -440,7 +494,7 @@
   {
     "term": "At start",
     "context": "At start",
-    "reference": "Modals/EventDetailsModal.qml:49, Modals/EventDetailsModal.qml:246, Modals/SettingsContent.qml:146, Modals/CalendarRemindersDialog.qml:34",
+    "reference": "Modals/CalendarRemindersDialog.qml:34, Modals/EventDetailsModal.qml:49, Modals/EventDetailsModal.qml:246, Modals/SettingsContent.qml:146",
     "comment": "default reminder dropdown option | event reminder dropdown option"
   },
   {
@@ -500,7 +554,7 @@
   {
     "term": "Calendar",
     "context": "Calendar",
-    "reference": "Modules/CalendarWindow.qml:352, Modules/CalendarWindow.qml:600",
+    "reference": "Modules/CalendarWindow.qml:387, Modules/CalendarWindow.qml:686",
     "comment": "main window title | main window title bar text"
   },
   {
@@ -530,7 +584,7 @@
   {
     "term": "Cancel",
     "context": "Cancel",
-    "reference": "Modals/ConfirmDialog.qml:72, Modals/EventDetailsModal.qml:666, Modals/NewCalendarDialog.qml:101, Modals/RenameCalendarDialog.qml:98, Modals/TaskDetailsModal.qml:513, Modals/AccountAddModal.qml:1134, Modals/CalendarRemindersDialog.qml:376",
+    "reference": "Modals/CalendarRemindersDialog.qml:376, Modals/ConfirmDialog.qml:72, Modals/NewCalendarDialog.qml:101, Modals/RenameCalendarDialog.qml:98, Modals/TaskDetailsModal.qml:513, Modals/AccountAddModal.qml:1134, Modals/EventDetailsModal.qml:666",
     "comment": "button to cancel oauth browser step | confirm dialog button to cancel | event form button to cancel editing | new calendar dialog button to cancel | per-calendar reminders dialog button to cancel | rename calendar dialog button to cancel | task form button to discard changes"
   },
   {
@@ -562,6 +616,12 @@
     "context": "Choose calendar directory",
     "reference": "Modals/AccountAddModal.qml:1455",
     "comment": "folder picker title for local calendar directory"
+  },
+  {
+    "term": "Clear",
+    "context": "Clear",
+    "reference": "Widgets/EventSelectionBar.qml:42",
+    "comment": "multi-event action shelf clear selection label"
   },
   {
     "term": "Clear event selection",
@@ -632,7 +692,7 @@
   {
     "term": "Confirm delete",
     "context": "Confirm delete",
-    "reference": "Modals/EventDetailsModal.qml:597, Modals/TaskDetailsModal.qml:503",
+    "reference": "Modals/TaskDetailsModal.qml:503, Modals/EventDetailsModal.qml:597",
     "comment": "event details button to confirm deleting the event | task form button to confirm deletion"
   },
   {
@@ -668,7 +728,7 @@
   {
     "term": "Connected",
     "context": "Connected",
-    "reference": "Modals/AccountAddModal.qml:1176, Modals/SettingsContent.qml:1194, Modals/SettingsAboutPage.qml:361",
+    "reference": "Modals/SettingsAboutPage.qml:361, Modals/AccountAddModal.qml:1176, Modals/SettingsContent.qml:1194",
     "comment": "about page daemon status value | account status in account list | success step status heading"
   },
   {
@@ -690,10 +750,40 @@
     "comment": "guide step next button"
   },
   {
+    "term": "Copied %1 events",
+    "context": "Copied %1 events",
+    "reference": "Widgets/EventSelectionModel.qml:143",
+    "comment": "clipboard confirmation for multiple events; %1 is event count"
+  },
+  {
+    "term": "Copied 1 event",
+    "context": "Copied 1 event",
+    "reference": "Widgets/EventSelectionModel.qml:143",
+    "comment": "clipboard confirmation for one event"
+  },
+  {
     "term": "Copied to clipboard",
     "context": "Copied to clipboard",
     "reference": "Modals/AccountAddModal.qml:930, Modals/AccountAddModal.qml:1269",
     "comment": "toast after copying text to the clipboard"
+  },
+  {
+    "term": "Copy",
+    "context": "Copy",
+    "reference": "Widgets/EventSelectionBar.qml:16",
+    "comment": "multi-event action shelf label"
+  },
+  {
+    "term": "Copy %1 events",
+    "context": "Copy %1 events",
+    "reference": "Widgets/EventContextMenu.qml:105",
+    "comment": "event context menu copy action; %1 is event count"
+  },
+  {
+    "term": "Copy event",
+    "context": "Copy event",
+    "reference": "Widgets/EventContextMenu.qml:105",
+    "comment": "event context menu copy action for one event"
   },
   {
     "term": "Copy link",
@@ -722,7 +812,7 @@
   {
     "term": "Couldn't update task",
     "context": "Couldn't update task",
-    "reference": "Services/DankCalService.qml:1078",
+    "reference": "Services/DankCalService.qml:1177",
     "comment": "toast when a task update fails"
   },
   {
@@ -734,7 +824,7 @@
   {
     "term": "Create event",
     "context": "Create event",
-    "reference": "Modules/CalendarSidebar.qml:419, Modals/KeyboardShortcutsOverlay.qml:140",
+    "reference": "Modals/KeyboardShortcutsOverlay.qml:140, Modules/CalendarSidebar.qml:419",
     "comment": "keyboard shortcut description | sidebar button to create a new event"
   },
   {
@@ -792,6 +882,12 @@
     "comment": "view switcher option in sidebar"
   },
   {
+    "term": "Day actions",
+    "context": "Day actions",
+    "reference": "Widgets/EventContextMenu.qml:56",
+    "comment": "subtitle for a calendar day context menu"
+  },
+  {
     "term": "Day view",
     "context": "Day view",
     "reference": "Modals/KeyboardShortcutsOverlay.qml:82",
@@ -812,7 +908,7 @@
   {
     "term": "Default reminder",
     "context": "Default reminder",
-    "reference": "Modals/SettingsContent.qml:588, Modals/CalendarRemindersDialog.qml:297",
+    "reference": "Modals/CalendarRemindersDialog.qml:297, Modals/SettingsContent.qml:588",
     "comment": "default reminder setting label | per-calendar default reminder override label"
   },
   {
@@ -824,14 +920,50 @@
   {
     "term": "Delete",
     "context": "Delete",
-    "reference": "Modules/CalendarSidebar.qml:302, Modals/TaskDetailsModal.qml:503, Modals/SettingsContent.qml:1018, Modals/SettingsContent.qml:1024",
-    "comment": "calendar row action tooltip | confirm button for deleting a calendar | delete calendar confirmation button | task form button to delete the task"
+    "reference": "Modals/TaskDetailsModal.qml:503, Modals/SettingsContent.qml:1018, Modals/SettingsContent.qml:1024, Modules/CalendarSidebar.qml:302, Widgets/EventSelectionBar.qml:36",
+    "comment": "calendar row action tooltip | confirm button for deleting a calendar | delete calendar confirmation button | multi-event action shelf label | task form button to delete the task"
   },
   {
     "term": "Delete \"%1\"?",
     "context": "Delete \"%1\"?",
-    "reference": "Modules/CalendarSidebar.qml:300, Modals/SettingsContent.qml:1022",
+    "reference": "Modals/SettingsContent.qml:1022, Modules/CalendarSidebar.qml:300",
     "comment": "confirm dialog title for deleting a calendar, %1 is the calendar name | delete calendar confirmation title"
+  },
+  {
+    "term": "Delete %1 events",
+    "context": "Delete %1 events",
+    "reference": "Modules/CalendarWindow.qml:331",
+    "comment": "confirmation button for deleting multiple events; %1 is event count"
+  },
+  {
+    "term": "Delete %1 events?",
+    "context": "Delete %1 events?",
+    "reference": "Modules/CalendarWindow.qml:329",
+    "comment": "confirmation title for deleting multiple events; %1 is event count"
+  },
+  {
+    "term": "Delete %1 events…",
+    "context": "Delete %1 events…",
+    "reference": "Widgets/EventContextMenu.qml:149",
+    "comment": "event context menu delete action; %1 is event count"
+  },
+  {
+    "term": "Delete event",
+    "context": "Delete event",
+    "reference": "Modules/CalendarWindow.qml:331",
+    "comment": "confirmation button for deleting one event"
+  },
+  {
+    "term": "Delete event?",
+    "context": "Delete event?",
+    "reference": "Modules/CalendarWindow.qml:329",
+    "comment": "confirmation title for deleting one event"
+  },
+  {
+    "term": "Delete event…",
+    "context": "Delete event…",
+    "reference": "Widgets/EventContextMenu.qml:149",
+    "comment": "event context menu delete action for one event"
   },
   {
     "term": "Delete occurrence",
@@ -872,13 +1004,13 @@
   {
     "term": "Disable core hours",
     "context": "Disable core hours",
-    "reference": "Modules/views/DayView.qml:163, Modules/views/WeekView.qml:255",
+    "reference": "Modules/views/WeekView.qml:291, Modules/views/DayView.qml:171",
     "comment": "core hours warning banner disable action"
   },
   {
     "term": "Disable sync",
     "context": "Disable sync",
-    "reference": "Modules/CalendarSidebar.qml:987, Modals/SettingsContent.qml:1011",
+    "reference": "Modals/SettingsContent.qml:1011, Modules/CalendarSidebar.qml:987",
     "comment": "calendar context menu action to stop syncing a calendar | calendar row action tooltip"
   },
   {
@@ -930,6 +1062,12 @@
     "comment": "task form toggle label for the due date"
   },
   {
+    "term": "Duplicate",
+    "context": "Duplicate",
+    "reference": "Widgets/EventContextMenu.qml:112",
+    "comment": "event context menu duplicate action"
+  },
+  {
     "term": "Edit event",
     "context": "Edit event",
     "reference": "Modals/EventDetailsModal.qml:511, Modals/EventDetailsModal.qml:563",
@@ -950,7 +1088,7 @@
   {
     "term": "Enable reminders",
     "context": "Enable reminders",
-    "reference": "Modals/SettingsContent.qml:1314, Modals/CalendarRemindersDialog.qml:273",
+    "reference": "Modals/CalendarRemindersDialog.qml:273, Modals/SettingsContent.qml:1314",
     "comment": "per-calendar enable reminders override label | reminders toggle label"
   },
   {
@@ -1058,7 +1196,7 @@
   {
     "term": "General",
     "context": "General",
-    "reference": "Modals/SettingsSidebar.qml:16, Modals/SettingsContent.qml:373, Modals/KeyboardShortcutsOverlay.qml:136",
+    "reference": "Modals/SettingsSidebar.qml:16, Modals/KeyboardShortcutsOverlay.qml:136, Modals/SettingsContent.qml:373",
     "comment": "general settings section header | keyboard shortcuts overlay section header | settings sidebar tab label"
   },
   {
@@ -1154,7 +1292,7 @@
   {
     "term": "Keep until dismissed",
     "context": "Keep until dismissed",
-    "reference": "Modals/SettingsContent.qml:1325, Modals/CalendarRemindersDialog.qml:285",
+    "reference": "Modals/CalendarRemindersDialog.qml:285, Modals/SettingsContent.qml:1325",
     "comment": "per-calendar persist override label | persistent reminders toggle label"
   },
   {
@@ -1214,7 +1352,7 @@
   {
     "term": "Local",
     "context": "Local",
-    "reference": "Modals/AccountAddModal.qml:125, Modals/AccountAddModal.qml:524, Modals/SettingsContent.qml:1099, Services/DankCalService.qml:1519",
+    "reference": "Modals/AccountAddModal.qml:125, Modals/AccountAddModal.qml:524, Modals/SettingsContent.qml:1099, Services/DankCalService.qml:1618",
     "comment": "local provider name in account add modal | local provider name in account list | provider label for a local account"
   },
   {
@@ -1244,7 +1382,7 @@
   {
     "term": "Marked as not done",
     "context": "Marked as not done",
-    "reference": "Services/DankCalService.qml:1081",
+    "reference": "Services/DankCalService.qml:1180",
     "comment": "toast after un-completing a task"
   },
   {
@@ -1314,10 +1452,22 @@
     "comment": "recurrence dropdown option | task recurrence dropdown option"
   },
   {
+    "term": "Move %1 events",
+    "context": "Move %1 events",
+    "reference": "Modules/views/MonthView.qml:581, Modules/views/WeekView.qml:845",
+    "comment": "event drag preview label; %1 is event count"
+  },
+  {
     "term": "Move through sidebar items",
     "context": "Move through sidebar items",
     "reference": "Modals/KeyboardShortcutsOverlay.qml:111",
     "comment": "keyboard shortcut description"
+  },
+  {
+    "term": "Move to selected day",
+    "context": "Move to selected day",
+    "reference": "Widgets/EventContextMenu.qml:131",
+    "comment": "event context menu move action"
   },
   {
     "term": "My calendars",
@@ -1358,8 +1508,8 @@
   {
     "term": "New event",
     "context": "New event",
-    "reference": "Modals/EventDetailsModal.qml:511, Modals/EventDetailsModal.qml:563, Modules/views/MonthView.qml:343",
-    "comment": "event modal header when creating | event modal window title when creating | placeholder label on the event span shown while selecting days in the month grid"
+    "reference": "Modals/EventDetailsModal.qml:511, Modals/EventDetailsModal.qml:563, Widgets/EventContextMenu.qml:60, Modules/views/MonthView.qml:385",
+    "comment": "calendar day context menu action | event modal header when creating | event modal window title when creating | placeholder label on the event span shown while selecting days in the month grid"
   },
   {
     "term": "New task",
@@ -1460,13 +1610,13 @@
   {
     "term": "No writable calendar available",
     "context": "No writable calendar available",
-    "reference": "Modals/EventDetailsModal.qml:338",
-    "comment": "event form error when no calendar allows creating events"
+    "reference": "Modals/EventDetailsModal.qml:338, Widgets/EventSelectionModel.qml:152, Widgets/EventSelectionModel.qml:178",
+    "comment": "event duplicate error when no calendar allows creating events | event form error when no calendar allows creating events | event paste error when no calendar allows creating events"
   },
   {
     "term": "None",
     "context": "None",
-    "reference": "Modals/EventDetailsModal.qml:45, Modals/TaskDetailsModal.qml:67, Modals/SettingsContent.qml:142, Modals/CalendarRemindersDialog.qml:30",
+    "reference": "Modals/CalendarRemindersDialog.qml:30, Modals/TaskDetailsModal.qml:67, Modals/EventDetailsModal.qml:45, Modals/SettingsContent.qml:142",
     "comment": "default reminder dropdown option | event reminder dropdown option | task priority dropdown option"
   },
   {
@@ -1490,7 +1640,7 @@
   {
     "term": "Nothing scheduled in the next %1 days",
     "context": "Nothing scheduled in the next %1 days",
-    "reference": "Modules/views/AgendaView.qml:101",
+    "reference": "Modules/views/AgendaView.qml:110",
     "comment": "agenda empty state, %1 is the number of days ahead"
   },
   {
@@ -1526,7 +1676,7 @@
   {
     "term": "On the day",
     "context": "On the day",
-    "reference": "Modals/SettingsContent.qml:192, Modals/CalendarRemindersDialog.qml:78",
+    "reference": "Modals/CalendarRemindersDialog.qml:78, Modals/SettingsContent.qml:192",
     "comment": "all-day reminder day dropdown option"
   },
   {
@@ -1546,6 +1696,12 @@
     "context": "Open browser again",
     "reference": "Modals/AccountAddModal.qml:1106",
     "comment": "button to reopen oauth url in browser"
+  },
+  {
+    "term": "Open event",
+    "context": "Open event",
+    "reference": "Widgets/EventContextMenu.qml:88",
+    "comment": "event context menu action"
   },
   {
     "term": "Open or create event",
@@ -1600,6 +1756,30 @@
     "context": "Password (optional)",
     "reference": "Modals/AccountAddModal.qml:1665",
     "comment": "ical optional basic-auth password field label"
+  },
+  {
+    "term": "Paste %1 events",
+    "context": "Paste %1 events",
+    "reference": "Widgets/EventContextMenu.qml:65",
+    "comment": "calendar day context menu paste action; %1 is event count"
+  },
+  {
+    "term": "Paste %1 events here",
+    "context": "Paste %1 events here",
+    "reference": "Widgets/EventContextMenu.qml:138",
+    "comment": "event context menu paste action; %1 is event count"
+  },
+  {
+    "term": "Paste 1 event",
+    "context": "Paste 1 event",
+    "reference": "Widgets/EventContextMenu.qml:65",
+    "comment": "calendar day context menu paste action for one event"
+  },
+  {
+    "term": "Paste 1 event here",
+    "context": "Paste 1 event here",
+    "reference": "Widgets/EventContextMenu.qml:138",
+    "comment": "event context menu paste action for one event"
   },
   {
     "term": "Paste credentials",
@@ -1688,8 +1868,20 @@
   {
     "term": "Quit",
     "context": "Quit",
-    "reference": "Modules/TrayIcon.qml:57, Modals/SettingsContent.qml:401",
+    "reference": "Modals/SettingsContent.qml:401, Modules/TrayIcon.qml:57",
     "comment": "close behavior button group option to quit the app | tray menu item to quit the application"
+  },
+  {
+    "term": "Read-only events can't be deleted",
+    "context": "Read-only events can't be deleted",
+    "reference": "Widgets/EventSelectionModel.qml:211",
+    "comment": "event delete error for a read-only calendar"
+  },
+  {
+    "term": "Read-only events can't be moved",
+    "context": "Read-only events can't be moved",
+    "reference": "Widgets/EventSelectionModel.qml:191",
+    "comment": "event move error for a read-only calendar"
   },
   {
     "term": "Reconnect",
@@ -1736,13 +1928,13 @@
   {
     "term": "Remove",
     "context": "Remove",
-    "reference": "Modules/CalendarSidebar.qml:313, Modals/SettingsContent.qml:1260",
+    "reference": "Modals/SettingsContent.qml:1260, Modules/CalendarSidebar.qml:313",
     "comment": "confirm button for removing an account | remove account confirmation button"
   },
   {
     "term": "Remove \"%1\"?",
     "context": "Remove \"%1\"?",
-    "reference": "Modules/CalendarSidebar.qml:311, Modals/SettingsContent.qml:1258",
+    "reference": "Modals/SettingsContent.qml:1258, Modules/CalendarSidebar.qml:311",
     "comment": "confirm dialog title for removing an account, %1 is the account label | remove account confirmation title"
   },
   {
@@ -1754,13 +1946,13 @@
   {
     "term": "Removes this account and its calendars and events from Dank Calendar. Nothing is deleted from the provider.",
     "context": "Removes this account and its calendars and events from Dank Calendar. Nothing is deleted from the provider.",
-    "reference": "Modules/CalendarSidebar.qml:312, Modals/SettingsContent.qml:1259",
+    "reference": "Modals/SettingsContent.qml:1259, Modules/CalendarSidebar.qml:312",
     "comment": "confirm dialog body for removing an account | remove account confirmation message"
   },
   {
     "term": "Removes this calendar and its events from Dank Calendar. If the provider still offers it, it will come back on the next sync.",
     "context": "Removes this calendar and its events from Dank Calendar. If the provider still offers it, it will come back on the next sync.",
-    "reference": "Modules/CalendarSidebar.qml:301, Modals/SettingsContent.qml:1023",
+    "reference": "Modals/SettingsContent.qml:1023, Modules/CalendarSidebar.qml:301",
     "comment": "confirm dialog body for deleting a calendar | delete calendar confirmation message"
   },
   {
@@ -1794,21 +1986,33 @@
     "comment": "task form label for the recurrence dropdown"
   },
   {
+    "term": "Repeat next week",
+    "context": "Repeat next week",
+    "reference": "Widgets/EventContextMenu.qml:125",
+    "comment": "event context menu quick repeat action"
+  },
+  {
+    "term": "Repeat tomorrow",
+    "context": "Repeat tomorrow",
+    "reference": "Widgets/EventContextMenu.qml:119",
+    "comment": "event context menu quick repeat action"
+  },
+  {
     "term": "Repeats",
     "context": "Repeats",
-    "reference": "Modals/EventDetailsModal.qml:281, Services/DankCalService.qml:900",
+    "reference": "Modals/EventDetailsModal.qml:281, Services/DankCalService.qml:999",
     "comment": "generic recurrence label for an unrecognized rule"
   },
   {
     "term": "Repeats every %1",
     "context": "Repeats every %1",
-    "reference": "Services/DankCalService.qml:902",
+    "reference": "Services/DankCalService.qml:1001",
     "comment": "recurrence label, %1 is a unit like 'day'"
   },
   {
     "term": "Repeats every %1 %2",
     "context": "Repeats every %1 %2",
-    "reference": "Services/DankCalService.qml:902",
+    "reference": "Services/DankCalService.qml:1001",
     "comment": "recurrence label, %1 is a count and %2 a unit like 'weeks'"
   },
   {
@@ -1820,7 +2024,7 @@
   {
     "term": "Save",
     "context": "Save",
-    "reference": "Modals/EventDetailsModal.qml:680, Modals/RenameCalendarDialog.qml:105, Modals/TaskDetailsModal.qml:522, Modals/CalendarRemindersDialog.qml:383",
+    "reference": "Modals/CalendarRemindersDialog.qml:383, Modals/RenameCalendarDialog.qml:105, Modals/TaskDetailsModal.qml:522, Modals/EventDetailsModal.qml:680",
     "comment": "event details button to save changes | per-calendar reminders dialog button to save | rename calendar dialog button to save name | task form button to persist the task"
   },
   {
@@ -1854,6 +2058,12 @@
     "comment": "search status title while search is running"
   },
   {
+    "term": "Select all %1 events",
+    "context": "Select all %1 events",
+    "reference": "Widgets/EventContextMenu.qml:73",
+    "comment": "calendar day context menu selection action; %1 is event count"
+  },
+  {
     "term": "Select client_secret.json",
     "context": "Select client_secret.json",
     "reference": "Modals/AccountAddModal.qml:984",
@@ -1864,6 +2074,12 @@
     "context": "Select days for a new event (month view)",
     "reference": "Modals/KeyboardShortcutsOverlay.qml:65",
     "comment": "keyboard shortcut description"
+  },
+  {
+    "term": "Select event",
+    "context": "Select event",
+    "reference": "Widgets/EventContextMenu.qml:73",
+    "comment": "calendar day context menu action for one event"
   },
   {
     "term": "Select file",
@@ -1916,7 +2132,7 @@
   {
     "term": "Show all-day reminders",
     "context": "Show all-day reminders",
-    "reference": "Modals/SettingsContent.qml:1364, Modals/CalendarRemindersDialog.qml:323",
+    "reference": "Modals/CalendarRemindersDialog.qml:323, Modals/SettingsContent.qml:1364",
     "comment": "all-day reminders toggle label | per-calendar all-day reminders override label"
   },
   {
@@ -2000,7 +2216,7 @@
   {
     "term": "Snooze duration",
     "context": "Snooze duration",
-    "reference": "Modals/SettingsContent.qml:1349, Modals/CalendarRemindersDialog.qml:310",
+    "reference": "Modals/CalendarRemindersDialog.qml:310, Modals/SettingsContent.qml:1349",
     "comment": "per-calendar snooze override label | snooze duration setting label"
   },
   {
@@ -2102,7 +2318,7 @@
   {
     "term": "Task completed",
     "context": "Task completed",
-    "reference": "Services/DankCalService.qml:1081",
+    "reference": "Services/DankCalService.qml:1180",
     "comment": "toast after completing a task"
   },
   {
@@ -2114,7 +2330,7 @@
   {
     "term": "Tasks",
     "context": "Tasks",
-    "reference": "Modules/CalendarSidebar.qml:58, Modules/CalendarSidebar.qml:660, Modules/CalendarContent.qml:45",
+    "reference": "Modules/CalendarSidebar.qml:58, Modules/CalendarSidebar.qml:660, Modules/CalendarContent.qml:49",
     "comment": "header title when the tasks view is active | sidebar section header for the task list | view switcher option in sidebar"
   },
   {
@@ -2142,10 +2358,22 @@
     "comment": "theme mode setting label"
   },
   {
+    "term": "These events will be deleted from their calendars. Recurring selections delete only the selected occurrences.",
+    "context": "These events will be deleted from their calendars. Recurring selections delete only the selected occurrences.",
+    "reference": "Modules/CalendarWindow.qml:330",
+    "comment": "confirmation body for deleting multiple events"
+  },
+  {
     "term": "This account cannot be reconnected — remove it and add it again.",
     "context": "This account cannot be reconnected — remove it and add it again.",
-    "reference": "Services/DankCalService.qml:1309",
+    "reference": "Services/DankCalService.qml:1408",
     "comment": "error when reconnect is unavailable for a provider"
+  },
+  {
+    "term": "This event will be deleted from its calendar.",
+    "context": "This event will be deleted from its calendar.",
+    "reference": "Modules/CalendarWindow.qml:330",
+    "comment": "confirmation body for deleting one event"
   },
   {
     "term": "Time format",
@@ -2156,13 +2384,13 @@
   {
     "term": "Title is required",
     "context": "Title is required",
-    "reference": "Modals/EventDetailsModal.qml:332, Modals/TaskDetailsModal.qml:194",
+    "reference": "Modals/TaskDetailsModal.qml:194, Modals/EventDetailsModal.qml:332",
     "comment": "event form validation error for missing title | task form validation error for missing title"
   },
   {
     "term": "Today",
     "context": "Today",
-    "reference": "Modules/CalendarContent.qml:66, Modals/SearchModal.qml:70, Modules/views/AgendaView.qml:42, Modules/views/TasksView.qml:32, Modules/views/TasksView.qml:54",
+    "reference": "Modals/SearchModal.qml:70, Modules/CalendarContent.qml:70, Modules/views/TasksView.qml:32, Modules/views/TasksView.qml:54, Modules/views/AgendaView.qml:50",
     "comment": "agenda section header for the current day | due-date label on a task card | header button that jumps to the current date | search result date label for current day | tasks view section header for tasks due today"
   },
   {
@@ -2180,7 +2408,7 @@
   {
     "term": "Tomorrow",
     "context": "Tomorrow",
-    "reference": "Modals/SearchModal.qml:72, Modules/views/AgendaView.qml:44, Modules/views/TasksView.qml:34",
+    "reference": "Modals/SearchModal.qml:72, Modules/views/TasksView.qml:34, Modules/views/AgendaView.qml:52",
     "comment": "agenda section header for the next day | due-date label on a task card | search result date label for next day"
   },
   {
@@ -2210,7 +2438,7 @@
   {
     "term": "Undo",
     "context": "Undo",
-    "reference": "Services/DankCalService.qml:1082",
+    "reference": "Services/DankCalService.qml:1181",
     "comment": "toast undo action"
   },
   {
@@ -2300,7 +2528,7 @@
   {
     "term": "Waiting for the dankcalendar daemon...",
     "context": "Waiting for the dankcalendar daemon...",
-    "reference": "Modules/views/AgendaView.qml:101, Modules/views/TasksView.qml:119",
+    "reference": "Modules/views/TasksView.qml:119, Modules/views/AgendaView.qml:110",
     "comment": "agenda placeholder while the daemon is not connected | tasks view placeholder while the daemon is not connected"
   },
   {
@@ -2372,8 +2600,14 @@
   {
     "term": "all day",
     "context": "all day",
-    "reference": "Modules/views/DayView.qml:202",
+    "reference": "Modules/views/DayView.qml:210",
     "comment": "suffix on all-day event chip in day view"
+  },
+  {
+    "term": "created",
+    "context": "created",
+    "reference": "Widgets/EventSelectionModel.qml:182",
+    "comment": "past-tense event action used in a result message"
   },
   {
     "term": "dark",
@@ -2384,20 +2618,32 @@
   {
     "term": "day",
     "context": "day",
-    "reference": "Services/DankCalService.qml:894",
+    "reference": "Services/DankCalService.qml:993",
     "comment": "recurrence unit singular"
   },
   {
     "term": "days",
     "context": "days",
-    "reference": "Services/DankCalService.qml:894, Widgets/DankRecurrencePicker.qml:63",
+    "reference": "Services/DankCalService.qml:993, Widgets/DankRecurrencePicker.qml:63",
     "comment": "recurrence unit plural"
+  },
+  {
+    "term": "deleted",
+    "context": "deleted",
+    "reference": "Widgets/EventSelectionModel.qml:216",
+    "comment": "past-tense event action used in a result message"
   },
   {
     "term": "e.g. 2022-01-01",
     "context": "e.g. 2022-01-01",
     "reference": "Modals/GoToDateDialog.qml:207",
     "comment": "go to date input placeholder example"
+  },
+  {
+    "term": "events",
+    "context": "events",
+    "reference": "Widgets/EventContextMenu.qml:42",
+    "comment": "plural event noun in context menu actions"
   },
   {
     "term": "iCal subscription",
@@ -2414,19 +2660,25 @@
   {
     "term": "month",
     "context": "month",
-    "reference": "Services/DankCalService.qml:896",
+    "reference": "Services/DankCalService.qml:995",
     "comment": "recurrence unit singular"
   },
   {
     "term": "months",
     "context": "months",
-    "reference": "Services/DankCalService.qml:896, Widgets/DankRecurrencePicker.qml:71",
+    "reference": "Services/DankCalService.qml:995, Widgets/DankRecurrencePicker.qml:71",
     "comment": "recurrence unit plural"
+  },
+  {
+    "term": "moved",
+    "context": "moved",
+    "reference": "Widgets/EventSelectionModel.qml:199",
+    "comment": "past-tense event action used in a result message"
   },
   {
     "term": "on %1",
     "context": "on %1",
-    "reference": "Services/DankCalService.qml:916",
+    "reference": "Services/DankCalService.qml:1015",
     "comment": "recurrence label suffix listing weekdays, %1 like 'Mon, Wed'"
   },
   {
@@ -2440,6 +2692,12 @@
     "context": "password",
     "reference": "Modals/AccountAddModal.qml:1304",
     "comment": "caldav password field placeholder"
+  },
+  {
+    "term": "pasted",
+    "context": "pasted",
+    "reference": "Widgets/EventSelectionModel.qml:160",
+    "comment": "past-tense event action used in a result message"
   },
   {
     "term": "read-only",
@@ -2474,7 +2732,7 @@
   {
     "term": "until %1",
     "context": "until %1",
-    "reference": "Services/DankCalService.qml:921",
+    "reference": "Services/DankCalService.qml:1020",
     "comment": "recurrence label suffix with an end date"
   },
   {
@@ -2486,25 +2744,25 @@
   {
     "term": "week",
     "context": "week",
-    "reference": "Services/DankCalService.qml:895",
+    "reference": "Services/DankCalService.qml:994",
     "comment": "recurrence unit singular"
   },
   {
     "term": "weeks",
     "context": "weeks",
-    "reference": "Services/DankCalService.qml:895, Widgets/DankRecurrencePicker.qml:67",
+    "reference": "Services/DankCalService.qml:994, Widgets/DankRecurrencePicker.qml:67",
     "comment": "recurrence unit plural"
   },
   {
     "term": "year",
     "context": "year",
-    "reference": "Services/DankCalService.qml:897",
+    "reference": "Services/DankCalService.qml:996",
     "comment": "recurrence unit singular"
   },
   {
     "term": "years",
     "context": "years",
-    "reference": "Services/DankCalService.qml:897, Widgets/DankRecurrencePicker.qml:75",
+    "reference": "Services/DankCalService.qml:996, Widgets/DankRecurrencePicker.qml:75",
     "comment": "recurrence unit plural"
   },
   {

--- a/quickshell/translations/template.json
+++ b/quickshell/translations/template.json
@@ -924,6 +924,13 @@
     "comment": ""
   },
   {
+    "term": "Copy selected events",
+    "translation": "",
+    "context": "keyboard shortcut description",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Core hours",
     "translation": "",
     "context": "core hours range setting label",
@@ -976,6 +983,41 @@
     "term": "Custom",
     "translation": "",
     "context": "color source button group option for a custom theme file | recurrence dropdown option",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Cut",
+    "translation": "",
+    "context": "multi-event action shelf label",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Cut %1 events",
+    "translation": "",
+    "context": "clipboard confirmation for multiple events; %1 is event count | event context menu cut action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Cut 1 event",
+    "translation": "",
+    "context": "clipboard confirmation for one event",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Cut event",
+    "translation": "",
+    "context": "event context menu cut action for one event",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Cut selected events",
+    "translation": "",
+    "context": "keyboard shortcut description",
     "reference": "",
     "comment": ""
   },
@@ -1134,6 +1176,13 @@
     "comment": ""
   },
   {
+    "term": "Delete selected events",
+    "translation": "",
+    "context": "keyboard shortcut description",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Delete series",
     "translation": "",
     "context": "event details button to confirm deleting a whole recurring series",
@@ -1241,7 +1290,21 @@
   {
     "term": "Duplicate",
     "translation": "",
-    "context": "event context menu duplicate action",
+    "context": "event context menu duplicate action for one event",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Duplicate %1 events",
+    "translation": "",
+    "context": "event context menu duplicate action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Duplicate selected events",
+    "translation": "",
+    "context": "keyboard shortcut description",
     "reference": "",
     "comment": ""
   },
@@ -1326,6 +1389,13 @@
     "term": "Event",
     "translation": "",
     "context": "event modal window title when viewing",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Event actions",
+    "translation": "",
+    "context": "keyboard shortcuts overlay section header",
     "reference": "",
     "comment": ""
   },
@@ -1701,6 +1771,20 @@
     "comment": ""
   },
   {
+    "term": "Move %1 events here",
+    "translation": "",
+    "context": "calendar context menu cut-paste action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Move 1 event here",
+    "translation": "",
+    "context": "calendar context menu cut-paste action for one event",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Move through sidebar items",
     "translation": "",
     "context": "keyboard shortcut description",
@@ -1988,6 +2072,13 @@
     "comment": ""
   },
   {
+    "term": "Open event actions",
+    "translation": "",
+    "context": "keyboard shortcut description",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Open or create event",
     "translation": "",
     "context": "keyboard shortcut description",
@@ -2086,6 +2177,13 @@
     "comment": ""
   },
   {
+    "term": "Paste events on the selected day",
+    "translation": "",
+    "context": "keyboard shortcut description",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Paste the Application (client) ID from your app registration's Overview page.",
     "translation": "",
     "context": "microsoft credentials step instructions",
@@ -2180,6 +2278,13 @@
     "term": "Quit",
     "translation": "",
     "context": "close behavior button group option to quit the app | tray menu item to quit the application",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Read-only events can't be cut",
+    "translation": "",
+    "context": "event cut error for a read-only calendar",
     "reference": "",
     "comment": ""
   },
@@ -2317,16 +2422,30 @@
     "comment": ""
   },
   {
+    "term": "Repeat %1 events next week",
+    "translation": "",
+    "context": "event context menu quick repeat action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Repeat %1 events tomorrow",
+    "translation": "",
+    "context": "event context menu quick repeat action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Repeat next week",
     "translation": "",
-    "context": "event context menu quick repeat action",
+    "context": "event context menu quick repeat action for one event",
     "reference": "",
     "comment": ""
   },
   {
     "term": "Repeat tomorrow",
     "translation": "",
-    "context": "event context menu quick repeat action",
+    "context": "event context menu quick repeat action for one event",
     "reference": "",
     "comment": ""
   },
@@ -3076,13 +3195,6 @@
     "term": "e.g. 2022-01-01",
     "translation": "",
     "context": "go to date input placeholder example",
-    "reference": "",
-    "comment": ""
-  },
-  {
-    "term": "events",
-    "translation": "",
-    "context": "plural event noun in context menu actions",
     "reference": "",
     "comment": ""
   },

--- a/quickshell/translations/template.json
+++ b/quickshell/translations/template.json
@@ -21,6 +21,34 @@
     "comment": ""
   },
   {
+    "term": "%1 events %2",
+    "translation": "",
+    "context": "multiple event action result; %1 is event count, %2 is an action verb",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "%1 events selected",
+    "translation": "",
+    "context": "event context menu selection summary; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "%1 of %2 events %3",
+    "translation": "",
+    "context": "partial batch event action result; %1 completed count, %2 total count, %3 action verb",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "%1 selected",
+    "translation": "",
+    "context": "multi-event action shelf selection count; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "%1 times",
     "translation": "",
     "context": "recurrence label suffix for a fixed number of occurrences",
@@ -98,6 +126,20 @@
     "comment": ""
   },
   {
+    "term": "+1 day",
+    "translation": "",
+    "context": "multi-event action shelf repeat tomorrow label",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "+1 week",
+    "translation": "",
+    "context": "multi-event action shelf repeat next week label",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "1 appointment falls outside core hours",
     "translation": "",
     "context": "core hours warning banner, singular",
@@ -108,6 +150,13 @@
     "term": "1 day before",
     "translation": "",
     "context": "all-day reminder day dropdown option | event reminder dropdown option",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "1 event %1",
+    "translation": "",
+    "context": "single event action result; %1 is an action verb",
     "reference": "",
     "comment": ""
   },
@@ -336,6 +385,13 @@
     "comment": ""
   },
   {
+    "term": "Actions apply to the whole selection",
+    "translation": "",
+    "context": "event context menu multi-selection hint",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Add",
     "translation": "",
     "context": "button to add evolution account | button to add local calendar account",
@@ -413,6 +469,13 @@
     "comment": ""
   },
   {
+    "term": "Again",
+    "translation": "",
+    "context": "multi-event action shelf duplicate label",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Agenda",
     "translation": "",
     "context": "header title when the agenda view is active | view switcher option in sidebar",
@@ -436,7 +499,7 @@
   {
     "term": "All day",
     "translation": "",
-    "context": "all-day marker in event tooltip | all-day marker in the month day-detail popover | event form toggle label for all-day events | search result subtitle for all-day events | time column label for all-day events on agenda card",
+    "context": "all-day marker in event context menu | all-day marker in event tooltip | all-day marker in the month day-detail popover | event form toggle label for all-day events | search result subtitle for all-day events | time column label for all-day events on agenda card",
     "reference": "",
     "comment": ""
   },
@@ -658,6 +721,13 @@
     "comment": ""
   },
   {
+    "term": "Clear",
+    "translation": "",
+    "context": "multi-event action shelf clear selection label",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Clear event selection",
     "translation": "",
     "context": "keyboard shortcut description",
@@ -805,9 +875,44 @@
     "comment": ""
   },
   {
+    "term": "Copied %1 events",
+    "translation": "",
+    "context": "clipboard confirmation for multiple events; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Copied 1 event",
+    "translation": "",
+    "context": "clipboard confirmation for one event",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Copied to clipboard",
     "translation": "",
     "context": "toast after copying text to the clipboard",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Copy",
+    "translation": "",
+    "context": "multi-event action shelf label",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Copy %1 events",
+    "translation": "",
+    "context": "event context menu copy action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Copy event",
+    "translation": "",
+    "context": "event context menu copy action for one event",
     "reference": "",
     "comment": ""
   },
@@ -924,6 +1029,13 @@
     "comment": ""
   },
   {
+    "term": "Day actions",
+    "translation": "",
+    "context": "subtitle for a calendar day context menu",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Day view",
     "translation": "",
     "context": "keyboard shortcut description",
@@ -961,7 +1073,7 @@
   {
     "term": "Delete",
     "translation": "",
-    "context": "calendar row action tooltip | confirm button for deleting a calendar | delete calendar confirmation button | task form button to delete the task",
+    "context": "calendar row action tooltip | confirm button for deleting a calendar | delete calendar confirmation button | multi-event action shelf label | task form button to delete the task",
     "reference": "",
     "comment": ""
   },
@@ -969,6 +1081,48 @@
     "term": "Delete \"%1\"?",
     "translation": "",
     "context": "confirm dialog title for deleting a calendar, %1 is the calendar name | delete calendar confirmation title",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Delete %1 events",
+    "translation": "",
+    "context": "confirmation button for deleting multiple events; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Delete %1 events?",
+    "translation": "",
+    "context": "confirmation title for deleting multiple events; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Delete %1 events…",
+    "translation": "",
+    "context": "event context menu delete action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Delete event",
+    "translation": "",
+    "context": "confirmation button for deleting one event",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Delete event?",
+    "translation": "",
+    "context": "confirmation title for deleting one event",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Delete event…",
+    "translation": "",
+    "context": "event context menu delete action for one event",
     "reference": "",
     "comment": ""
   },
@@ -1081,6 +1235,13 @@
     "term": "Due date",
     "translation": "",
     "context": "task form toggle label for the due date",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Duplicate",
+    "translation": "",
+    "context": "event context menu duplicate action",
     "reference": "",
     "comment": ""
   },
@@ -1533,9 +1694,23 @@
     "comment": ""
   },
   {
+    "term": "Move %1 events",
+    "translation": "",
+    "context": "event drag preview label; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Move through sidebar items",
     "translation": "",
     "context": "keyboard shortcut description",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Move to selected day",
+    "translation": "",
+    "context": "event context menu move action",
     "reference": "",
     "comment": ""
   },
@@ -1584,7 +1759,7 @@
   {
     "term": "New event",
     "translation": "",
-    "context": "event modal header when creating | event modal window title when creating | placeholder label on the event span shown while selecting days in the month grid",
+    "context": "calendar day context menu action | event modal header when creating | event modal window title when creating | placeholder label on the event span shown while selecting days in the month grid",
     "reference": "",
     "comment": ""
   },
@@ -1703,7 +1878,7 @@
   {
     "term": "No writable calendar available",
     "translation": "",
-    "context": "event form error when no calendar allows creating events",
+    "context": "event duplicate error when no calendar allows creating events | event form error when no calendar allows creating events | event paste error when no calendar allows creating events",
     "reference": "",
     "comment": ""
   },
@@ -1806,6 +1981,13 @@
     "comment": ""
   },
   {
+    "term": "Open event",
+    "translation": "",
+    "context": "event context menu action",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Open or create event",
     "translation": "",
     "context": "keyboard shortcut description",
@@ -1865,6 +2047,34 @@
     "term": "Password (optional)",
     "translation": "",
     "context": "ical optional basic-auth password field label",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Paste %1 events",
+    "translation": "",
+    "context": "calendar day context menu paste action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Paste %1 events here",
+    "translation": "",
+    "context": "event context menu paste action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Paste 1 event",
+    "translation": "",
+    "context": "calendar day context menu paste action for one event",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Paste 1 event here",
+    "translation": "",
+    "context": "event context menu paste action for one event",
     "reference": "",
     "comment": ""
   },
@@ -1970,6 +2180,20 @@
     "term": "Quit",
     "translation": "",
     "context": "close behavior button group option to quit the app | tray menu item to quit the application",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Read-only events can't be deleted",
+    "translation": "",
+    "context": "event delete error for a read-only calendar",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Read-only events can't be moved",
+    "translation": "",
+    "context": "event move error for a read-only calendar",
     "reference": "",
     "comment": ""
   },
@@ -2093,6 +2317,20 @@
     "comment": ""
   },
   {
+    "term": "Repeat next week",
+    "translation": "",
+    "context": "event context menu quick repeat action",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Repeat tomorrow",
+    "translation": "",
+    "context": "event context menu quick repeat action",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Repeats",
     "translation": "",
     "context": "generic recurrence label for an unrecognized rule",
@@ -2163,6 +2401,13 @@
     "comment": ""
   },
   {
+    "term": "Select all %1 events",
+    "translation": "",
+    "context": "calendar day context menu selection action; %1 is event count",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "Select client_secret.json",
     "translation": "",
     "context": "file picker title for google client json",
@@ -2173,6 +2418,13 @@
     "term": "Select days for a new event (month view)",
     "translation": "",
     "context": "keyboard shortcut description",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "Select event",
+    "translation": "",
+    "context": "calendar day context menu action for one event",
     "reference": "",
     "comment": ""
   },
@@ -2499,9 +2751,23 @@
     "comment": ""
   },
   {
+    "term": "These events will be deleted from their calendars. Recurring selections delete only the selected occurrences.",
+    "translation": "",
+    "context": "confirmation body for deleting multiple events",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "This account cannot be reconnected — remove it and add it again.",
     "translation": "",
     "context": "error when reconnect is unavailable for a provider",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "This event will be deleted from its calendar.",
+    "translation": "",
+    "context": "confirmation body for deleting one event",
     "reference": "",
     "comment": ""
   },
@@ -2772,6 +3038,13 @@
     "comment": ""
   },
   {
+    "term": "created",
+    "translation": "",
+    "context": "past-tense event action used in a result message",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "dark",
     "translation": "",
     "context": "current scheme name in theme mode description",
@@ -2793,9 +3066,23 @@
     "comment": ""
   },
   {
+    "term": "deleted",
+    "translation": "",
+    "context": "past-tense event action used in a result message",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "e.g. 2022-01-01",
     "translation": "",
     "context": "go to date input placeholder example",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "events",
+    "translation": "",
+    "context": "plural event noun in context menu actions",
     "reference": "",
     "comment": ""
   },
@@ -2828,6 +3115,13 @@
     "comment": ""
   },
   {
+    "term": "moved",
+    "translation": "",
+    "context": "past-tense event action used in a result message",
+    "reference": "",
+    "comment": ""
+  },
+  {
     "term": "on %1",
     "translation": "",
     "context": "recurrence label suffix listing weekdays, %1 like 'Mon, Wed'",
@@ -2845,6 +3139,13 @@
     "term": "password",
     "translation": "",
     "context": "caldav password field placeholder",
+    "reference": "",
+    "comment": ""
+  },
+  {
+    "term": "pasted",
+    "translation": "",
+    "context": "past-tense event action used in a result message",
     "reference": "",
     "comment": ""
   },


### PR DESCRIPTION
## Summary

- add Ctrl/Command-click toggles and Shift-click ranges for selecting events across month, week, day, and agenda views
- add event and day context menus for copy, cut, paste, duplicate, repeat tomorrow, repeat next week, move, and confirmed deletion
- add a compact selection action shelf plus discoverable keyboard shortcuts, including Delete/Backspace for selected events
- drag selected event groups between days while preserving each event's time, duration, and relative day spacing
- exchange copied events through an iCalendar-compatible system clipboard payload; cut-paste creates every destination event before deleting any source event
- keep all new interface text localized with translator context

## Interaction details

- Right-clicking an event keeps an existing multi-selection intact and applies actions to the whole selection.
- Right-clicking a day offers new-event, paste/move-here, and select-all actions.
- Ctrl+C, Ctrl+X, Ctrl+V, Ctrl+D, Delete/Backspace, and the Menu key mirror the visible actions.
- Read-only selections disable destructive actions, and deleting one or many events always asks for confirmation.

## Testing

- `make test`
- `make vet`
- `make build`
- `make i18n-test` (478 translated terms with context)
- `/usr/lib/qt6/bin/qmltestrunner -input quickshell/tests -import quickshell -o -,txt` (9 passed)
- parsed every changed QML file with `qmlformat`
- ran the applicable repository hook checks for trailing whitespace, final newlines, and prohibited `console.*` calls
- launched the in-repo QML config with hot reload against an isolated local calendar and visually checked month-view selection, context-menu spacing, and keyboard-shortcut help


## Visuals

https://github.com/user-attachments/assets/ac126cf3-f071-4f4d-b5b6-c5d8b0032f70

<img width="1274" height="1432" alt="dankcalendar-multi-select-context" src="https://github.com/user-attachments/assets/6997c323-0b8b-428a-8328-d0c871010aad" />
<img width="1274" height="1432" alt="dankcalendar-event-shortcuts" src="https://github.com/user-attachments/assets/5b6da230-4761-491a-ba80-17a082b3d03f" />

