### PR TITLE
caldav: Don't quote multistatus bodies with entity encoded quotes

### DIFF
--- a/core/internal/providers/caldav/etag.go
+++ b/core/internal/providers/caldav/etag.go
@@ -51,7 +51,20 @@ func (t etagNormalizingTransport) RoundTrip(req *http.Request) (*http.Response, 
 func normalizeETagXML(body []byte) []byte {
 	return getETagRe.ReplaceAllFunc(body, func(m []byte) []byte {
 		sub := getETagRe.FindSubmatch(m)
-		quoted := quoteETag(string(sub[2]))
+
+		etag := string(sub[2])
+		trimmed := strings.TrimSpace(etag)
+		// The ETAG may be quoted with entity encoded quotes which are valid according
+		// to the XML standard and go-webdav properly supports them. As such they must
+		// also be considered as quoted and skipped, otherwise they will end up double
+		// quoted and error during processing.
+		quoted := ""
+		if strings.HasPrefix(trimmed, "&quot;") && strings.HasSuffix(trimmed, "&quot;") {
+			quoted = etag
+		} else {
+			quoted = quoteETag(etag)
+		}
+
 		return append(append(sub[1], quoted...), sub[3]...)
 	})
 }

--- a/core/internal/providers/caldav/etag_test.go
+++ b/core/internal/providers/caldav/etag_test.go
@@ -22,6 +22,7 @@ func TestQuoteETag(t *testing.T) {
 		{"empty", ``, ``},
 		{"whitespace only", `  `, `  `},
 		{"padded unquoted", ` 1234-5678 `, `"1234-5678"`},
+		{"entity encoded (does not apply)", ` &quot;1234-5678&quot; `, `"&quot;1234-5678&quot;"`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -50,6 +51,11 @@ func TestNormalizeETagXML(t *testing.T) {
 			"quoted left alone",
 			`<d:getetag>"abc"</d:getetag>`,
 			`<d:getetag>"abc"</d:getetag>`,
+		},
+		{
+			"entity encoded left alone",
+			`<d:getetag>&quot;abc&quot;</d:getetag>`,
+			`<d:getetag>&quot;abc&quot;</d:getetag>`,
 		},
 		{
 			"empty left alone",
@@ -114,4 +120,35 @@ func TestETagNormalizingTransport(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, `"1755-372673"`, resp.Header.Get("Etag"))
+}
+
+// Nextcloud returns getetag values with quotes entity encoded; the transport
+// must not modify multistatus bodies if this is the case.
+func TestETagNormalizingTransportEntityEncoded(t *testing.T) {
+	const multistatus = `<?xml version="1.0" encoding="UTF-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/caldav/cal/event.ics</d:href>
+    <d:propstat>
+      <d:prop><d:getetag>&quot;1755-372673&quot;</d:getetag></d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeMultiStatus(w, multistatus)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Transport: etagNormalizingTransport{base: http.DefaultTransport}}
+
+	req, err := http.NewRequest("REPORT", server.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `<d:getetag>&quot;1755-372673&quot;</d:getetag>`)
 }


### PR DESCRIPTION
XML pre-defines the `&quot;` entity to escape quotes [^1], this is not strictly necessary inside entity's character data (text) but it is supported and processors must support it [^2]. The go xml package and by extension go-webdav support it.

As part of the fix for non-compliant servers sending unquoted ETags (#81, https://github.com/AvengeMedia/dankcalendar/commit/771a09e2af7df5f10e6b2a5103d473c04e94e06f), compliant servers sending entity encoded quotes, namely Nextcloud, stopped working as their etags were now quoted twice which is not a valid etag.

Adds a check that the etag is not quoted with entity encoded quotes before applying the fix.

[^1]: https://www.w3.org/TR/xml11/#sec-predefined-ent
[^2]: https://www.w3.org/TR/xml11/#entproc