### PR TITLE
oauthbase: persist tokens only on refresh

### DIFF
--- a/core/internal/providers/oauthbase/oauthbase.go
+++ b/core/internal/providers/oauthbase/oauthbase.go
@@ -15,9 +15,9 @@ import (
 )
 
 // LoadTokenSource reads the account's stored app credentials and OAuth token and
-// returns a token source that refreshes and re-persists the token on every use.
-// C is the provider's app-credentials type; build turns it into the oauth2
-// config used to refresh.
+// returns a token source that refreshes the token and re-persists it on each
+// refresh. C is the provider's app-credentials type; build turns it into the
+// oauth2 config used to refresh.
 func LoadTokenSource[C any](ctx context.Context, secrets cal.SecretStore, account cal.Account, appKey, tokenKey string, build func(C) *oauth2.Config) (oauth2.TokenSource, error) {
 	appBytes, err := secrets.Get(ctx, account.ID, appKey)
 	if err != nil {
@@ -39,12 +39,12 @@ func LoadTokenSource[C any](ctx context.Context, secrets cal.SecretStore, accoun
 		return nil, err
 	}
 
-	return &persistingTokenSource{
+	return oauth2.ReuseTokenSource(tok, &persistingTokenSource{
 		base:      build(creds).TokenSource(ctx, tok),
 		secrets:   secrets,
 		accountID: account.ID,
 		tokenKey:  tokenKey,
-	}, nil
+	}), nil
 }
 
 // ClassifyAuthErr wraps ErrReauthRequired around dead-credential failures so the

--- a/core/internal/providers/oauthbase/oauthbase_test.go
+++ b/core/internal/providers/oauthbase/oauthbase_test.go
@@ -1,0 +1,68 @@
+package oauthbase
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	cal "github.com/AvengeMedia/dankcalendar/core/internal/calendar"
+	"github.com/AvengeMedia/dankcalendar/core/internal/mocks"
+)
+
+type countingSource struct {
+	calls int
+	tok   oauth2.Token
+}
+
+func (c *countingSource) Token() (*oauth2.Token, error) {
+	c.calls++
+	t := c.tok
+	return &t, nil
+}
+
+func TestValidTokenNeverWrites(t *testing.T) {
+	stored, err := json.Marshal(oauth2.Token{AccessToken: "a", Expiry: time.Now().Add(time.Hour)})
+	require.NoError(t, err)
+
+	store := mocks.NewMockSecretStore(t)
+	store.EXPECT().Get(mock.Anything, "acct", "app").Return([]byte(`{}`), nil)
+	store.EXPECT().Get(mock.Anything, "acct", "token").Return(stored, nil)
+
+	src, err := LoadTokenSource(context.Background(), store, cal.Account{ID: "acct"}, "app", "token", func(struct{}) *oauth2.Config {
+		return &oauth2.Config{}
+	})
+	require.NoError(t, err)
+
+	for range 5 {
+		_, err := src.Token()
+		require.NoError(t, err)
+	}
+}
+
+func TestRefreshWritesOnce(t *testing.T) {
+	var written []byte
+	store := mocks.NewMockSecretStore(t)
+	store.EXPECT().Set(mock.Anything, "acct", "token", mock.Anything).
+		RunAndReturn(func(_ context.Context, _, _ string, data []byte) error {
+			written = data
+			return nil
+		}).Once()
+
+	refresher := &countingSource{tok: oauth2.Token{AccessToken: "new", Expiry: time.Now().Add(time.Hour)}}
+	src := oauth2.ReuseTokenSource(nil, &persistingTokenSource{base: refresher, secrets: store, accountID: "acct", tokenKey: "token"})
+
+	for range 5 {
+		_, err := src.Token()
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, refresher.calls)
+
+	var tok oauth2.Token
+	require.NoError(t, json.Unmarshal(written, &tok))
+	require.Equal(t, "new", tok.AccessToken)
+}


### PR DESCRIPTION
Every Google API call was writing the OAuth token back to the keyring, even when nothing had changed. The wrapper that saves the token sat outside the caching source that oauth2 gives us, so it ran on every request instead of just when a refresh happened.

This moves the wrapper inside oauth2.ReuseTokenSource. Now the token is only written when it has actually been refreshed, which is roughly once an hour instead of dozens of times per sync. Microsoft was already behaving this way because oauth2.NewClient adds its own cache, so this just brings Google in line.

Added two tests: one checks that a still-valid token never triggers a write, the other checks that a refresh triggers exactly one write with the new token.